### PR TITLE
feat: preferUniversal option

### DIFF
--- a/src/models/PecansReleases.ts
+++ b/src/models/PecansReleases.ts
@@ -1,4 +1,4 @@
-import { sortRelaseBySemVerDescending } from "../utils";
+import { sortReleaseBySemVerDescending } from "../utils";
 import { PecansChannel } from "./PecansChannel";
 import { PecansRelease } from "./PecansRelease";
 import { PecansReleaseQuery } from "./PecansReleaseQuery";
@@ -10,7 +10,7 @@ export class PecansReleases {
   protected releases: PecansRelease[] = [];
 
   constructor(releases: PecansRelease[]) {
-    this.releases = releases.sort(sortRelaseBySemVerDescending);
+    this.releases = releases.sort(sortReleaseBySemVerDescending);
     releases.forEach((release) => {
       if (!this.idxReleaseByChannel[release.channel]) {
         this.idxReleaseByChannel[release.channel] = [release];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,5 +6,5 @@ export * from "./channelFromVersion";
 export * from "./mergeReleaseNotes";
 export * from "./resolveForVersion";
 export * from "./satisfiesPlatform";
-export * from "./sortRelaseBySemVerDescending";
+export * from "./sortReleaseBySemVerDescending";
 export * from "./win-releases";

--- a/src/utils/sortReleaseBySemVerDescending.ts
+++ b/src/utils/sortReleaseBySemVerDescending.ts
@@ -2,7 +2,7 @@ import { gt } from "semver";
 import { PecansRelease } from "../models";
 
 // Compare two version
-export function sortRelaseBySemVerDescending(
+export function sortReleaseBySemVerDescending(
   a: PecansRelease,
   b: PecansRelease
 ) {

--- a/test/platforms.spec.ts
+++ b/test/platforms.spec.ts
@@ -217,16 +217,45 @@ const fileNameByPlatformTests: [platform: Platform, filename: string][] = [
   ["linux_deb_64", "atom-amd64.deb"],
 ];
 
+const fileNameByPlatformUniversalTests: [platform: Platform, filename: string][] = [
+  [platforms.OSX, "test-3.3.1-darwin-universal.dmg"],
+  [platforms.OSX_UNIVERSAL, "test-3.3.1-darwin-universal.dmg"],
+  [platforms.OSX_64, "test-3.3.1-darwin-universal.dmg"],
+  [platforms.OSX_ARM64, "test-3.3.1-darwin-universal.dmg"],
+  [platforms.WINDOWS_32, "AtomSetup.exe"],
+  [platforms.LINUX_64, "atom-amd64.tar.gz"],
+  [platforms.LINUX_32, "atom-ia32.tar.gz"],
+  [platforms.LINUX_RPM_32, "atom-ia32.rpm"],
+  [platforms.LINUX_RPM_64, "atom-amd64.rpm"],
+  [platforms.LINUX_DEB_32, "atom-ia32.deb"],
+  [platforms.LINUX_DEB_64, "atom-amd64.deb"],
+];
+
 const fileNameByPlatformAndExtTests: [
   platform: Platform,
   ext: SupportedFileExtension,
   filename: string
 ][] = [
-  ["osx_64", ".zip", "test-3.3.1-darwin-x64.zip"],
-  ["osx_arm64", ".zip", "test-3.3.1-darwin-arm64.zip"],
-  [platforms.OSX_UNIVERSAL, ".zip", "test-3.3.1-darwin-universal.zip"],
-  [platforms.OSX_UNIVERSAL, ".dmg", "test-3.3.1-darwin-universal.dmg"],
-];
+    ["osx_64", ".zip", "test-3.3.1-darwin-x64.zip"],
+    ["osx_arm64", ".zip", "test-3.3.1-darwin-arm64.zip"],
+    [platforms.OSX_UNIVERSAL, ".zip", "test-3.3.1-darwin-universal.zip"],
+    [platforms.OSX_UNIVERSAL, ".dmg", "test-3.3.1-darwin-universal.dmg"],
+  ];
+
+const fileNameByPlatformAndExtUniversalTests: [
+  platform: Platform,
+  ext: SupportedFileExtension,
+  filename: string
+][] = [
+    [platforms.OSX, ".zip", "test-3.3.1-darwin-universal.zip"],
+    [platforms.OSX_UNIVERSAL, ".zip", "test-3.3.1-darwin-universal.zip"],
+    [platforms.OSX_64, ".zip", "test-3.3.1-darwin-universal.zip"],
+    [platforms.OSX_ARM64, ".zip", "test-3.3.1-darwin-universal.zip"],
+    [platforms.OSX, ".dmg", "test-3.3.1-darwin-universal.dmg"],
+    [platforms.OSX_UNIVERSAL, ".dmg", "test-3.3.1-darwin-universal.dmg"],
+    [platforms.OSX_64, ".dmg", "test-3.3.1-darwin-universal.dmg"],
+    [platforms.OSX_ARM64, ".dmg", "test-3.3.1-darwin-universal.dmg"],
+  ];
 
 describe("Platforms", function () {
   describe("filenameToOperatingSystem", () => {
@@ -284,14 +313,63 @@ describe("Platforms", function () {
   describe("resolveReleaseAssetForVersion", function () {
     fileNameByPlatformTests.forEach(([platform, filename]) => {
       it(`resolves ${platform} to ${filename}`, () => {
-        const target = resolveReleaseAssetForVersion(release, platform);
+        const target = resolveReleaseAssetForVersion(release, platform, false);
         should(target.filename).be.exactly(filename);
       });
     });
     fileNameByPlatformAndExtTests.forEach(([platform, ext, filename]) => {
       it(`resolves ${platform}, ${ext} to ${filename}`, () => {
-        const target = resolveReleaseAssetForVersion(release, platform, ext);
+        const target = resolveReleaseAssetForVersion(release, platform, false, ext);
         should(target.filename).be.exactly(filename);
+      });
+    });
+  });
+
+  describe("resolveReleaseAssetForVersion with preferUniversal", function () {
+
+    // test that we resolve to universal assets when preferUniversal is true
+    fileNameByPlatformUniversalTests.forEach(([platform, filename]) => {
+      it(`resolves ${platform} to ${filename}`, () => {
+        const target = resolveReleaseAssetForVersion(release, platform, true);
+        should(target.filename).be.exactly(filename);
+      });
+    });
+
+    // test that we fall back to conventional assets when universal are not available
+    const releaseWithoutUniversal = {
+      ...release,
+      assets: release.assets.filter((asset) => asset.type !== "osx_universal"),
+    }
+    fileNameByPlatformTests.forEach(([platform, filename]) => {
+      it(`resolves ${platform} to ${filename}`, () => {
+        const target = resolveReleaseAssetForVersion(releaseWithoutUniversal, platform, true);
+        if (platform === platforms.OSX_UNIVERSAL) {
+          // these have been removed, so expect undefined
+          should(target).be.undefined();
+        } else {
+          should(target.filename).be.exactly(filename);
+        }
+      });
+    });
+
+    // test that we resolve to universal assets when preferUniversal is true and the extension is specified
+    fileNameByPlatformAndExtUniversalTests.forEach(([platform, ext, filename]) => {
+      it(`resolves ${platform}, ${ext} to ${filename}`, () => {
+        const target = resolveReleaseAssetForVersion(release, platform, true, ext);
+        should(target.filename).be.exactly(filename);
+      });
+    });
+
+    // test that we fall back to conventional assets when universal are not available and the extension is specified
+    fileNameByPlatformAndExtTests.forEach(([platform, ext, filename]) => {
+      it(`resolves ${platform}, ${ext} to ${filename}`, () => {
+        const target = resolveReleaseAssetForVersion(releaseWithoutUniversal, platform, true, ext);
+        if (platform === platforms.OSX_UNIVERSAL) {
+          // these have been removed, so expect undefined
+          should(target).be.undefined();
+        } else {
+          should(target.filename).be.exactly(filename);
+        }
       });
     });
   });


### PR DESCRIPTION
When the preferUniversal option is set (default = true), deliver universal assets (if available), when OSX users request x64 or arm64.

+tests

…also a couple of spelling fixes