### PR TITLE
feat: includeVersionInReleaseNotes setting

### DIFF
--- a/src/pecans.ts
+++ b/src/pecans.ts
@@ -50,9 +50,11 @@ export interface PecansSettings {
   cacheMaxAge: number;
   /** If universal build exists, prefer it over platform specific builds */
   preferUniversal: boolean;
+  /** Whether to include version in the aggregation of release notes when comparing versions */
+  includeVersionInReleaseNotes: boolean;
 }
 
-export interface PecansOptions extends Partial<PecansSettings> {}
+export interface PecansOptions extends Partial<PecansSettings> { }
 
 export class UnsupportedPlatformError extends Error {
   constructor(platform: unknown) {
@@ -179,6 +181,7 @@ export class Pecans extends EventEmitter {
     cacheMaxAge: 60 * 60 * 2,
     basePath: "",
     preferUniversal: true,
+    includeVersionInReleaseNotes: false,
   };
 
   protected releasesCache: Record<string, Promise<PecansReleases>> = {};
@@ -488,21 +491,21 @@ export class Pecans extends EventEmitter {
       const asset = filename
         ? release.assets.find((i) => i.filename == filename)
         : resolveReleaseAssetForVersion(
-            release,
-            platform,
-            this.opts.preferUniversal,
-            filetype
-          );
+          release,
+          platform,
+          this.opts.preferUniversal,
+          filetype
+        );
 
       if (!asset)
         throw new Error(
           "No download available for platform " +
-            platform +
-            " for version " +
-            release.version +
-            " (" +
-            (channel || "beta") +
-            ")"
+          platform +
+          " for version " +
+          release.version +
+          " (" +
+          (channel || "beta") +
+          ")"
         );
 
       // Call analytic middleware, then serve
@@ -558,10 +561,12 @@ export class Pecans extends EventEmitter {
 
       const notesSlice =
         versions.length === 1 ? [latest] : versions.slice(0, -1);
-      const releaseNotes = mergeReleaseNotes(notesSlice, false);
-      const url = `${this.getBaseUrl(req)}/download/version/${
-        latest.version
-      }/${platform}?filetype=${filetype}`;
+      const url = `${this.getBaseUrl(req)}/download/version/${latest.version
+        }/${platform}?filetype=${filetype}`;
+      const releaseNotes = mergeReleaseNotes(
+        notesSlice,
+        this.opts.includeVersionInReleaseNotes
+      );
 
       res.status(200).send({
         url,


### PR DESCRIPTION
While most of the code is already there, there is no setting for whether to include version information when aggregating the release notes while reporting on a new update. This PR adds a `includeVersionInReleaseNotes` option to allow configuration of this setting.

This pull request includes changes to the `src/pecans.ts` file to add a new feature for including the version in the aggregation of release notes when comparing versions. The most important changes are:

Enhancements to release notes:

* [`src/pecans.ts`](diffhunk://#diff-7ae1ad317450ebda642f914cb1ce08fe37934c60c34ee4f5c5e407e05d6d70cbR53-R54): Added a new setting `includeVersionInReleaseNotes` to the `PecansSettings` interface to control whether the version should be included in the aggregation of release notes.
* [`src/pecans.ts`](diffhunk://#diff-7ae1ad317450ebda642f914cb1ce08fe37934c60c34ee4f5c5e407e05d6d70cbR184): Updated the default options in the `Pecans` class to include the new `includeVersionInReleaseNotes` setting with a default value of `false`.
* [`src/pecans.ts`](diffhunk://#diff-7ae1ad317450ebda642f914cb1ce08fe37934c60c34ee4f5c5e407e05d6d70cbL561-R569): Modified the logic in the `Pecans` class to use the new `includeVersionInReleaseNotes` setting when merging release notes.