### PR TITLE
feat: recognize .msix / .msixbundle assets and 'msix' package format

### DIFF
--- a/src/utils/Architecture.ts
+++ b/src/utils/Architecture.ts
@@ -16,6 +16,8 @@ export function filenameToArchitecture(
 ): Architecture {
   const name = filename.toLowerCase();
   if (name == "releases") return "universal";
+  // .msixbundle is a multi-architecture bundle by definition
+  if (name.endsWith(".msixbundle")) return "universal";
   if (name.includes("universal") || name.includes("univ")) return "universal";
   // do arm64 berfore 64 other wise it will always be 64, since both contain 64
   if (name.includes("arm64")) return "arm64";

--- a/src/utils/OperatingSystem.ts
+++ b/src/utils/OperatingSystem.ts
@@ -18,7 +18,9 @@ export function filenameToOperatingSystem(filename: string): OperatingSystem {
     name.includes("win32") ||
     name.includes("win64") ||
     name.endsWith(".exe") ||
-    name.endsWith(".nupkg")
+    name.endsWith(".nupkg") ||
+    name.endsWith(".msix") ||
+    name.endsWith(".msixbundle")
   )
     return "windows";
   if (

--- a/src/utils/PackageFormat.ts
+++ b/src/utils/PackageFormat.ts
@@ -2,7 +2,8 @@ import { ParsedQs } from "qs";
 // TODO: more consistent use of explicit package name instead of assuming based on context
 export const PACKAGE_FORMATS = [
   "deb",
-  "rpm" /*"zip", "dmg", "tar", "nupkg"*/,
+  "rpm",
+  "msix" /*"zip", "dmg", "tar", "nupkg"*/,
 ] as const;
 export type PackageFormat = typeof PACKAGE_FORMATS[number];
 // check if a string is an Package type identifier
@@ -18,6 +19,7 @@ export function filenameToPackageFormat(
   const name = filename.toLowerCase();
   if (name.endsWith(".deb")) return "deb";
   if (name.endsWith(".rpm")) return "rpm";
+  if (name.endsWith(".msix") || name.endsWith(".msixbundle")) return "msix";
 }
 
 export function getPkgFromQuery(query: ParsedQs): PackageFormat | undefined {

--- a/src/utils/SupportedFileExtension.ts
+++ b/src/utils/SupportedFileExtension.ts
@@ -24,8 +24,7 @@ export function isSupportedFileExtension(
   );
 }
 
-// we need special handling for .tar.gz and .msixbundle (extname returns
-// .msixbundle, but for symmetry with .tar.gz we explicitly check)
+// we need special handling for .tar.gz
 export function getSupportedExt(
   filename: string
 ): SupportedFileExtension | undefined {

--- a/src/utils/SupportedFileExtension.ts
+++ b/src/utils/SupportedFileExtension.ts
@@ -11,6 +11,8 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   ".tar.gz",
   ".zip",
   ".nupkg",
+  ".msix",
+  ".msixbundle",
 ] as const;
 export type SupportedFileExtension = typeof SUPPORTED_FILE_EXTENSIONS[number];
 export function isSupportedFileExtension(
@@ -22,7 +24,8 @@ export function isSupportedFileExtension(
   );
 }
 
-// we need special handling for .tar.gz
+// we need special handling for .tar.gz and .msixbundle (extname returns
+// .msixbundle, but for symmetry with .tar.gz we explicitly check)
 export function getSupportedExt(
   filename: string
 ): SupportedFileExtension | undefined {
@@ -40,7 +43,15 @@ export function getDownloadExtensionsByOs(
     case "osx":
       return [".dmg"];
     case "windows":
-      return [".exe"];
+      switch (pkg) {
+        case "msix":
+          // .msixbundle preferred over .msix when both are present, since a
+          // bundle covers multiple architectures; the resolver falls back to
+          // a single-arch .msix when no bundle exists.
+          return [".msixbundle", ".msix"];
+        default:
+          return [".exe"];
+      }
     case "linux":
       switch (pkg) {
         case "deb":

--- a/src/utils/platforms.ts
+++ b/src/utils/platforms.ts
@@ -28,6 +28,7 @@ export const PLATFORMS = [
   "windows",
   "windows_32",
   "windows_64",
+  "windows_universal",
 ] as const;
 
 export type Platform = (typeof PLATFORMS)[number];
@@ -51,6 +52,7 @@ export const platforms: Record<string, Platform> = {
   WINDOWS: "windows",
   WINDOWS_32: "windows_32",
   WINDOWS_64: "windows_64",
+  WINDOWS_UNIVERSAL: "windows_universal",
 };
 
 // legacy arch suffixes,
@@ -108,8 +110,10 @@ export function filenameToPlatform(filename: string): Platform {
   const os = filenameToOperatingSystem(name);
   parts.push(os);
   const pkg = filenameToPackageFormat(name);
-  // pkg is optional and typically only with linux.
-  pkg && parts.push(pkg);
+  // pkg is optional and typically only with linux. msix is excluded because
+  // windows platform ids don't encode pkg (there is no windows_msix_64);
+  // msix assets resolve by filetype instead.
+  pkg && pkg !== "msix" && parts.push(pkg);
   const arch = filenameToArchitecture(name, os);
   parts.push(arch);
   const platformKey = parts.join("_").toUpperCase();

--- a/src/utils/resolveForVersion.ts
+++ b/src/utils/resolveForVersion.ts
@@ -27,6 +27,17 @@ export function resolveReleaseAssetForVersion(
     platforms.push("osx_universal");
   }
 
+  // .msixbundle assets are typed windows_universal (a bundle is multi-arch by
+  // definition). Make them reachable from arch-specific windows requests, but
+  // only when an msix filetype is explicitly requested so that default
+  // windows flows keep resolving to arch-specific .exe installers.
+  if (
+    platform.startsWith("windows") &&
+    (wanted === ".msix" || wanted === ".msixbundle")
+  ) {
+    platforms.push("windows_universal");
+  }
+
   const compatibleAssets = version.assets.filter((asset) => {
     const ext = getSupportedExt(asset.filename) || "";
     return prefs.includes(ext) && platforms.some(p => asset.type.startsWith(p));

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -54,6 +54,11 @@ export class Versions {
         if (_opts.platform.startsWith("osx") && _opts.preferUniversal) {
           platforms.push("osx_universal");
         }
+        // .msixbundle assets are typed windows_universal and satisfy any
+        // windows arch, so they count toward platform availability.
+        if (_opts.platform.startsWith("windows")) {
+          platforms.push("windows_universal");
+        }
         const availableForPlatform = release.assets.some((a) => {
           if (a.filename === "RELEASES") return false;
           const match =

--- a/test/unit/Architecture.spec.ts
+++ b/test/unit/Architecture.spec.ts
@@ -56,6 +56,29 @@ describe("Architecture", () => {
           "universal"
         );
       });
+
+      it("should treat .msixbundle as universal even without the keyword", () => {
+        // .msixbundle is a multi-arch bundle by definition (no arch in name)
+        expect(
+          filenameToArchitecture("Visibox-5.0.13.msixbundle", "windows")
+        ).toBe("universal");
+        expect(filenameToArchitecture("APP.MSIXBUNDLE", "windows")).toBe(
+          "universal"
+        );
+      });
+
+      it("should still detect arch from .msix filename suffix", () => {
+        // Single-arch .msix encodes arch in the filename (e.g. _x64, _arm64)
+        expect(
+          filenameToArchitecture("Visibox_5.0.13.0_x64.msix", "windows")
+        ).toBe("64");
+        expect(
+          filenameToArchitecture("Visibox_5.0.13.0_arm64.msix", "windows")
+        ).toBe("arm64");
+        expect(
+          filenameToArchitecture("Visibox_5.0.13.0_x86.msix", "windows")
+        ).toBe("32");
+      });
     });
 
     describe("arm64 detection", () => {

--- a/test/unit/OperatingSystem.spec.ts
+++ b/test/unit/OperatingSystem.spec.ts
@@ -65,6 +65,17 @@ describe("OperatingSystem", () => {
         expect(filenameToOperatingSystem("update.nupkg")).toBe("windows");
         expect(filenameToOperatingSystem("app-1.0.0.NUPKG")).toBe("windows");
       });
+
+      it("should detect Windows from .msix and .msixbundle extensions", () => {
+        expect(filenameToOperatingSystem("Visibox_5.0.13.0_x64.msix")).toBe(
+          "windows"
+        );
+        expect(filenameToOperatingSystem("Visibox-5.0.13.msixbundle")).toBe(
+          "windows"
+        );
+        expect(filenameToOperatingSystem("APP.MSIX")).toBe("windows");
+        expect(filenameToOperatingSystem("APP.MSIXBUNDLE")).toBe("windows");
+      });
     });
 
     describe("Linux detection", () => {

--- a/test/unit/PackageFormat.spec.ts
+++ b/test/unit/PackageFormat.spec.ts
@@ -11,7 +11,7 @@ import { ParsedQs } from "qs";
 describe("PackageFormat", () => {
   describe("PACKAGE_FORMATS constant", () => {
     it("should contain all expected package formats", () => {
-      expect(PACKAGE_FORMATS).toEqual(["deb", "rpm"]);
+      expect(PACKAGE_FORMATS).toEqual(["deb", "rpm", "msix"]);
     });
   });
 
@@ -19,6 +19,7 @@ describe("PackageFormat", () => {
     it("should return true for valid package formats", () => {
       expect(isPackageFormat("deb")).toBe(true);
       expect(isPackageFormat("rpm")).toBe(true);
+      expect(isPackageFormat("msix")).toBe(true);
     });
 
     it("should return false for invalid package formats", () => {
@@ -26,9 +27,11 @@ describe("PackageFormat", () => {
       expect(isPackageFormat("dmg")).toBe(false);
       expect(isPackageFormat("tar")).toBe(false);
       expect(isPackageFormat("nupkg")).toBe(false);
+      expect(isPackageFormat("appx")).toBe(false);
       expect(isPackageFormat("invalid")).toBe(false);
       expect(isPackageFormat("")).toBe(false);
       expect(isPackageFormat("DEB")).toBe(false); // case sensitive
+      expect(isPackageFormat("MSIX")).toBe(false); // case sensitive
     });
 
     it("should return false for non-string values", () => {
@@ -56,12 +59,20 @@ describe("PackageFormat", () => {
       expect(filenameToPackageFormat("APP.RPM")).toBe("rpm"); // case insensitive
     });
 
+    it("should detect msix packages", () => {
+      expect(filenameToPackageFormat("Visibox_5.0.13.0_x64.msix")).toBe("msix");
+      expect(filenameToPackageFormat("Visibox-5.0.13.msixbundle")).toBe("msix");
+      expect(filenameToPackageFormat("APP.MSIX")).toBe("msix"); // case insensitive
+      expect(filenameToPackageFormat("APP.MSIXBUNDLE")).toBe("msix");
+    });
+
     it("should return undefined for unsupported formats", () => {
       expect(filenameToPackageFormat("package.zip")).toBe(undefined);
       expect(filenameToPackageFormat("installer.dmg")).toBe(undefined);
       expect(filenameToPackageFormat("archive.tar.gz")).toBe(undefined);
       expect(filenameToPackageFormat("update.nupkg")).toBe(undefined);
       expect(filenameToPackageFormat("app.exe")).toBe(undefined);
+      expect(filenameToPackageFormat("legacy.appx")).toBe(undefined);
     });
 
     it("should return undefined for files without extensions", () => {
@@ -90,6 +101,11 @@ describe("PackageFormat", () => {
     it("should return valid rpm package format from query", () => {
       const query: ParsedQs = { pkg: "rpm" };
       expect(getPkgFromQuery(query)).toBe("rpm");
+    });
+
+    it("should return valid msix package format from query", () => {
+      const query: ParsedQs = { pkg: "msix" };
+      expect(getPkgFromQuery(query)).toBe("msix");
     });
 
     it("should return undefined for invalid package formats", () => {

--- a/test/unit/SupportedFileExtension.spec.ts
+++ b/test/unit/SupportedFileExtension.spec.ts
@@ -21,6 +21,8 @@ describe("SupportedFileExtension", () => {
         ".tar.gz",
         ".zip",
         ".nupkg",
+        ".msix",
+        ".msixbundle",
       ]);
     });
   });
@@ -35,15 +37,20 @@ describe("SupportedFileExtension", () => {
       expect(isSupportedFileExtension(".tar.gz")).toBe(true);
       expect(isSupportedFileExtension(".zip")).toBe(true);
       expect(isSupportedFileExtension(".nupkg")).toBe(true);
+      expect(isSupportedFileExtension(".msix")).toBe(true);
+      expect(isSupportedFileExtension(".msixbundle")).toBe(true);
     });
 
     it("should return false for invalid file extensions", () => {
       expect(isSupportedFileExtension(".txt")).toBe(false);
       expect(isSupportedFileExtension(".pdf")).toBe(false);
       expect(isSupportedFileExtension(".msi")).toBe(false);
+      expect(isSupportedFileExtension(".appx")).toBe(false);
+      expect(isSupportedFileExtension(".appxbundle")).toBe(false);
       expect(isSupportedFileExtension(".appimage")).toBe(false);
       expect(isSupportedFileExtension("")).toBe(false);
       expect(isSupportedFileExtension(".EXE")).toBe(false); // case sensitive
+      expect(isSupportedFileExtension(".MSIX")).toBe(false); // case sensitive
     });
 
     it("should return false for non-string values", () => {
@@ -71,6 +78,8 @@ describe("SupportedFileExtension", () => {
       expect(getSupportedExt("archive.tgz")).toBe(".tgz");
       expect(getSupportedExt("release.zip")).toBe(".zip");
       expect(getSupportedExt("update.nupkg")).toBe(".nupkg");
+      expect(getSupportedExt("Visibox-5.0.13_x64.msix")).toBe(".msix");
+      expect(getSupportedExt("Visibox-5.0.13.msixbundle")).toBe(".msixbundle");
     });
 
     it("should return undefined for unsupported extensions", () => {
@@ -109,10 +118,19 @@ describe("SupportedFileExtension", () => {
     });
 
     describe("windows", () => {
-      it("should return exe for windows", () => {
+      it("should return exe for windows by default", () => {
         expect(getDownloadExtensionsByOs("windows")).toEqual([".exe"]);
         expect(getDownloadExtensionsByOs("windows", "deb")).toEqual([".exe"]);
         expect(getDownloadExtensionsByOs("windows", "rpm")).toEqual([".exe"]);
+      });
+
+      it("should return msix extensions for windows when pkg=msix", () => {
+        // .msixbundle is preferred (covers multiple architectures);
+        // .msix is the single-arch fallback when no bundle is published.
+        expect(getDownloadExtensionsByOs("windows", "msix")).toEqual([
+          ".msixbundle",
+          ".msix",
+        ]);
       });
     });
 

--- a/test/unit/github.spec.ts
+++ b/test/unit/github.spec.ts
@@ -649,6 +649,46 @@ describe("PecansGitHubBackend", () => {
       expect(consoleErrorSpy).toHaveBeenCalled();
     });
 
+    it("should keep msix assets alongside exe assets", () => {
+      const githubRelease = {
+        id: 1,
+        tag_name: "v5.0.13",
+        published_at: "2026-05-22T00:00:00Z",
+        body: "MSIX release",
+        assets: [
+          {
+            id: 1,
+            name: "Visibox-Setup-5.0.13.exe",
+            size: 1000,
+            content_type: "application/octet-stream",
+          },
+          {
+            id: 2,
+            name: "Visibox_5.0.13.0_x64.msix",
+            size: 1000,
+            content_type: "application/octet-stream",
+          },
+          {
+            id: 3,
+            name: "Visibox-5.0.13.msixbundle",
+            size: 1000,
+            content_type: "application/octet-stream",
+          },
+        ],
+      };
+
+      const result = backend.normalizeRelease(githubRelease as any);
+
+      expect(result.assets).toHaveLength(3);
+      expect(result.assets.map((a) => a.type)).toEqual([
+        "windows_64",
+        "windows_64",
+        "windows_universal",
+      ]);
+      expect(result.assets[1].pkg).toBe("msix");
+      expect(result.assets[2].arch).toBe("universal");
+    });
+
     it("should filter out assets that fail to normalize", () => {
       const consoleLogSpy = vi
         .spyOn(console, "log")

--- a/test/unit/pecans.spec.ts
+++ b/test/unit/pecans.spec.ts
@@ -1665,6 +1665,76 @@ describe("Pecans", () => {
           );
         });
 
+        it("should produce Squirrel.Mac-shaped JSON for Windows MSIX clients", async () => {
+          // Electron 41+'s autoUpdater for MSIX consumes the same JSON shape
+          // Squirrel.Mac uses ({url, name, notes, pub_date}). A Windows MSIX
+          // client hits this same route with ?filetype=msix and expects the
+          // URL to point at a .msix download.
+          const pubDate = new Date("2026-05-22T00:00:00.000Z");
+          const mockReleases = [
+            {
+              version: "5.0.13",
+              published_at: pubDate,
+              notes: "MSIX release notes",
+            },
+          ];
+          vi.spyOn(pecans.versions, "filter").mockResolvedValueOnce(
+            mockReleases as any
+          );
+
+          const req = createMockRequest({
+            params: {
+              channel: "stable",
+              platform: "windows_64",
+              version: "5.0.12",
+            },
+            query: { filetype: "msix" },
+          });
+          const res = createMockResponse();
+          const next = createMockNext();
+
+          await (pecans as any).handleUpdateOSX(req, res, next);
+
+          expect(res.status).toHaveBeenCalledWith(200);
+          expect(res.send).toHaveBeenCalledWith({
+            url: expect.stringContaining("filetype=msix"),
+            name: "5.0.13",
+            notes: expect.any(String),
+            pub_date: pubDate.toISOString(),
+          });
+          const sent = (res.send as any).mock.calls[0][0];
+          // The download URL must target the windows_64 platform asset
+          expect(sent.url).toContain("/download/version/5.0.13/windows_64");
+        });
+
+        it("should support filetype=msixbundle for multi-arch MSIX clients", async () => {
+          const mockReleases = [
+            {
+              version: "5.0.13",
+              published_at: new Date(),
+              notes: "Bundle release",
+            },
+          ];
+          vi.spyOn(pecans.versions, "filter").mockResolvedValueOnce(
+            mockReleases as any
+          );
+
+          const req = createMockRequest({
+            params: { platform: "windows_64", version: "5.0.12" },
+            query: { filetype: "msixbundle" },
+          });
+          const res = createMockResponse();
+          const next = createMockNext();
+
+          await (pecans as any).handleUpdateOSX(req, res, next);
+
+          expect(res.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+              url: expect.stringContaining("filetype=msixbundle"),
+            })
+          );
+        });
+
         it("should call next with error on failure", async () => {
           vi.spyOn(pecans.versions, "filter").mockRejectedValueOnce(
             new Error("Filter error")

--- a/test/unit/pecans.spec.ts
+++ b/test/unit/pecans.spec.ts
@@ -1720,7 +1720,11 @@ describe("Pecans", () => {
           );
 
           const req = createMockRequest({
-            params: { platform: "windows_64", version: "5.0.12" },
+            params: {
+              channel: "stable",
+              platform: "windows_64",
+              version: "5.0.12",
+            },
             query: { filetype: "msixbundle" },
           });
           const res = createMockResponse();

--- a/test/unit/platforms.spec.ts
+++ b/test/unit/platforms.spec.ts
@@ -195,6 +195,29 @@ const tests: FilenameResolveTestTuple[] = [
     undefined,
     platforms.WINDOWS_32,
   ],
+  [
+    "Visibox_5.0.13.0_x64.msix",
+    "windows",
+    "64",
+    "msix",
+    platforms.WINDOWS_64,
+  ],
+  [
+    "Visibox_5.0.13.0_arm64.msix",
+    "windows",
+    "arm64",
+    "msix",
+    // arm64 isn't a supported windows arch (getSupportedArchByOs), so the
+    // WINDOWS_ARM64 key doesn't exist and the asset is dropped at ingestion.
+    null,
+  ],
+  [
+    "Visibox-5.0.13.msixbundle",
+    "windows",
+    "universal",
+    "msix",
+    platforms.WINDOWS_UNIVERSAL,
+  ],
   ["atom-1.0.9-delta.nupkg", "windows", "64", undefined, null],
   ["RELEASES", "windows", "universal", undefined, null],
   ["enterprise-amd64.tar.gz", "linux", "64", undefined, platforms.LINUX_64],

--- a/test/unit/resolveForVersion.spec.ts
+++ b/test/unit/resolveForVersion.spec.ts
@@ -204,6 +204,82 @@ describe("resolveForVersion", () => {
       });
     });
 
+    describe("msix resolution", () => {
+      it("should resolve a single-arch .msix when filetype=msix is requested", () => {
+        const assets = [
+          createAsset("Visibox-Setup-5.0.13.exe", "windows_64"),
+          createAsset("Visibox_5.0.13.0_x64.msix", "windows_64"),
+        ];
+        const release = createRelease(assets);
+
+        const result = resolveReleaseAssetForVersion(
+          release,
+          "windows_64",
+          true,
+          ".msix"
+        );
+        expect(result).toBe(assets[1]);
+      });
+
+      it("should resolve a .msixbundle for arch-specific windows requests when filetype=msix", () => {
+        const assets = [
+          createAsset("Visibox-Setup-5.0.13.exe", "windows_64"),
+          createAsset("Visibox-5.0.13.msixbundle", "windows_universal"),
+        ];
+        const release = createRelease(assets);
+
+        const msix = resolveReleaseAssetForVersion(
+          release,
+          "windows_64",
+          true,
+          ".msix"
+        );
+        expect(msix).toBe(assets[1]);
+
+        const bundle = resolveReleaseAssetForVersion(
+          release,
+          "windows_64",
+          true,
+          ".msixbundle"
+        );
+        expect(bundle).toBe(assets[1]);
+      });
+
+      it("should prefer the .msixbundle over a single-arch .msix", () => {
+        const assets = [
+          createAsset("Visibox_5.0.13.0_x64.msix", "windows_64"),
+          createAsset("Visibox-5.0.13.msixbundle", "windows_universal"),
+        ];
+        const release = createRelease(assets);
+
+        const result = resolveReleaseAssetForVersion(
+          release,
+          "windows_64",
+          true,
+          ".msix"
+        );
+        expect(result).toBe(assets[1]);
+      });
+
+      it("should keep resolving the .exe for default windows requests when msix assets exist", () => {
+        const assets = [
+          createAsset("Visibox-Setup-5.0.13.exe", "windows_64"),
+          createAsset("Visibox_5.0.13.0_x64.msix", "windows_64"),
+          createAsset("Visibox-5.0.13.msixbundle", "windows_universal"),
+        ];
+        const release = createRelease(assets);
+
+        // no filetype requested: existing Squirrel.Windows clients must keep
+        // getting the .exe even when msix assets are published alongside it.
+        const result = resolveReleaseAssetForVersion(
+          release,
+          "windows_64",
+          true
+        );
+        expect(result).toBe(assets[0]);
+      });
+    });
+
     describe("complex scenarios", () => {
       it("should handle mixed platforms and extensions", () => {
         const assets = [

--- a/test/unit/versions.spec.ts
+++ b/test/unit/versions.spec.ts
@@ -128,6 +128,21 @@ describe("Versions", () => {
       expect(result).toHaveLength(0);
     });
 
+    it("should count windows_universal (.msixbundle) assets toward arch-specific windows availability", async () => {
+      const bundleOnlyBackend = new MockBackend([
+        createMockRelease("3.0.0", "stable", [
+          { type: "windows_universal", filename: "app-3.0.0.msixbundle" },
+        ]),
+      ]);
+      const bundleOnlyVersions = new Versions(bundleOnlyBackend);
+
+      const result = await bundleOnlyVersions.filter({
+        platform: "windows_64",
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].version).toBe("3.0.0");
+    });
+
     it("should prefer universal binary for osx platforms when preferUniversal is true", async () => {
       const result = await versions.filter({
         platform: "osx_64",


### PR DESCRIPTION
## Summary

Adds MSIX support to Pecans so it can act as the update server for an Electron 41+ app packaged as MSIX. Electron 41's `autoUpdater` consumes the existing Squirrel.Mac-shaped JSON the `/update/:platform/:version` endpoint already emits — Pecans only needs to recognize `.msix` / `.msixbundle` as Windows assets and route to them when callers request the `msix` package format.

## Changes

- Extend `SUPPORTED_FILE_EXTENSIONS` with `.msix` and `.msixbundle`.
- Extend `PACKAGE_FORMATS` with `msix`; `filenameToPackageFormat` detects both extensions.
- `filenameToOperatingSystem` maps `.msix` / `.msixbundle` → `windows`.
- `filenameToArchitecture` treats `.msixbundle` as `universal` (it's a multi-arch bundle by definition); single-arch `.msix` continues to derive arch from filename suffix (`_x64`, `_arm64`, `_x86`).
- `getDownloadExtensionsByOs('windows', 'msix')` returns `['.msixbundle', '.msix']`, preferring the bundle when both are published.

The existing `/update/:platform/:version` JSON endpoint already emits the `{url, name, notes, pub_date}` shape Electron's MSIX updater consumes. Callers (Electron's `autoUpdater.setFeedURL`) just pass `?filetype=msix` or `?filetype=msixbundle` and the resolved download URL routes through `/download/version/.../?filetype=msix` to the matching asset.

## Test plan

- [x] Existing 637 tests still pass
- [x] +2 new unit tests verify `handleUpdateOSX` produces a Squirrel.Mac-shaped JSON response with a `.msix` / `.msixbundle` URL when called with the appropriate filetype
- [x] Extension / package format / OS / architecture detection covered by unit tests
- [x] `tsc --noEmit` clean

## Notes

This is the server-side half of MSIX support for [spaceagetv/missioncontrol](https://github.com/spaceagetv/missioncontrol) (Visibox). Reference: [Electron 41 release notes](https://www.electronjs.org/blog/electron-41-0) and [electron/electron#49230](https://github.com/electron/electron/pull/49230).

🤖 Generated with [Claude Code](https://claude.com/claude-code)