### PR TITLE
test: complete e2e contract suite for the full route surface (Phase 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/express": "^4.17.13",
         "@types/express-useragent": "^1.0.2",
         "@types/semver": "^7.3.9",
-        "@types/supertest": "^2.0.12",
+        "@types/supertest": "^6.0.3",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
         "nanoid": "^3.3.6",
@@ -35,7 +35,7 @@
         "nodemon": "^2.0.16",
         "semantic-release": "^21.1.1",
         "sinon": "^14.0.0",
-        "supertest": "^6.2.3",
+        "supertest": "^7.2.2",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       },
@@ -901,6 +901,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1165,6 +1178,16 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2100,10 +2123,11 @@
       }
     },
     "node_modules/@types/cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
-      "dev": true
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -2170,6 +2194,13 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -2232,22 +2263,27 @@
       }
     },
     "node_modules/@types/superagent": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.18.tgz",
-      "integrity": "sha512-LOWgpacIV8GHhrsQU+QMZuomfqXiqzz3ILLkCtKx3Us6AmomFViuzKT9D693QTKgyut2oCytMG8/efOop+DB+w==",
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/cookiejar": "*",
-        "@types/node": "*"
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/supertest": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz",
-      "integrity": "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/superagent": "*"
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -2562,7 +2598,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2604,8 +2641,9 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2826,13 +2864,30 @@
         "node": ">=8"
       }
     },
-    "node_modules/call-bind": {
+    "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3033,6 +3088,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3051,10 +3107,14 @@
       }
     },
     "node_modules/component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3220,7 +3280,8 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -3362,8 +3423,9 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3396,6 +3458,7 @@
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
       "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -3432,6 +3495,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer2": {
@@ -3621,12 +3698,58 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -3862,7 +3985,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -4008,47 +4132,38 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/formidable/node_modules/qs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/forwarded": {
@@ -4107,9 +4222,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -4121,17 +4240,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4275,6 +4417,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -4349,6 +4503,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -4365,10 +4520,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4376,10 +4532,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4396,13 +4557,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "dev": true,
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">= 0.4"
       }
     },
     "node_modules/hook-std": {
@@ -5275,6 +5439,15 @@
       },
       "peerDependencies": {
         "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/media-typer": {
@@ -9052,9 +9225,13 @@
       "license": "ISC"
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10505,13 +10682,72 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10873,24 +11109,24 @@
       "license": "MIT"
     },
     "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "component-emitter": "^1.3.0",
+        "component-emitter": "^1.3.1",
         "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
+        "debug": "^4.3.7",
         "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
+        "qs": "^6.14.1"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/superagent/node_modules/mime": {
@@ -10898,6 +11134,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -10906,12 +11143,14 @@
       }
     },
     "node_modules/superagent/node_modules/qs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -10921,16 +11160,28 @@
       }
     },
     "node_modules/supertest": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
-      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "cookie-signature": "^1.2.2",
         "methods": "^1.1.2",
-        "superagent": "^8.0.5"
+        "superagent": "^10.3.0"
       },
       "engines": {
-        "node": ">=6.4.0"
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {
@@ -12450,6 +12701,12 @@
         "strict-event-emitter": "^0.5.1"
       }
     },
+    "@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12646,6 +12903,15 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
+    },
+    "@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "requires": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -13255,9 +13521,9 @@
       }
     },
     "@types/cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
     },
     "@types/debug": {
@@ -13322,6 +13588,12 @@
         "@types/express": "*"
       }
     },
+    "@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -13383,22 +13655,25 @@
       }
     },
     "@types/superagent": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.18.tgz",
-      "integrity": "sha512-LOWgpacIV8GHhrsQU+QMZuomfqXiqzz3ILLkCtKx3Us6AmomFViuzKT9D693QTKgyut2oCytMG8/efOop+DB+w==",
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
       "dev": true,
       "requires": {
-        "@types/cookiejar": "*",
-        "@types/node": "*"
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "@types/supertest": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz",
-      "integrity": "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
       "dev": true,
       "requires": {
-        "@types/superagent": "*"
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "@vitest/coverage-v8": {
@@ -13671,7 +13946,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "at-least-node": {
@@ -13840,13 +14115,22 @@
         }
       }
     },
-    "call-bind": {
+    "call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "callsites": {
@@ -13999,9 +14283,9 @@
       }
     },
     "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
       "dev": true
     },
     "concat-map": {
@@ -14229,7 +14513,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "depd": {
@@ -14279,6 +14563,16 @@
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
+      }
+    },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
       }
     },
     "duplexer2": {
@@ -14419,11 +14713,41 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
     "es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
     },
     "esbuild": {
       "version": "0.25.10",
@@ -14708,37 +15032,27 @@
       }
     },
     "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       }
     },
     "formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
       "requires": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.11.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-          "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-          "dev": true,
-          "requires": {
-            "side-channel": "^1.0.4"
-          }
-        }
+        "once": "^1.4.0"
       }
     },
     "forwarded": {
@@ -14780,9 +15094,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -14791,14 +15105,29 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "get-stream": {
@@ -14909,6 +15238,11 @@
         }
       }
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -14968,6 +15302,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -14978,15 +15313,19 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
-    "has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
-    },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -14994,11 +15333,13 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
-    "hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "dev": true
+    "hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "hook-std": {
       "version": "3.0.0",
@@ -15676,6 +16017,11 @@
         "node-emoji": "^1.11.0",
         "supports-hyperlinks": "^2.2.0"
       }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -18257,9 +18603,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
     },
     "on-finished": {
       "version": "2.4.1",
@@ -19262,13 +19608,47 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       }
     },
     "siginfo": {
@@ -19560,21 +19940,20 @@
       }
     },
     "superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
       "requires": {
-        "component-emitter": "^1.3.0",
+        "component-emitter": "^1.3.1",
         "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
+        "debug": "^4.3.7",
         "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
+        "qs": "^6.14.1"
       },
       "dependencies": {
         "mime": {
@@ -19584,24 +19963,34 @@
           "dev": true
         },
         "qs": {
-          "version": "6.11.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-          "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+          "version": "6.15.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+          "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
           "dev": true,
           "requires": {
-            "side-channel": "^1.0.4"
+            "es-define-property": "^1.0.1",
+            "side-channel": "^1.1.1"
           }
         }
       }
     },
     "supertest": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
-      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
       "requires": {
+        "cookie-signature": "^1.2.2",
         "methods": "^1.1.2",
-        "superagent": "^8.0.5"
+        "superagent": "^10.3.0"
+      },
+      "dependencies": {
+        "cookie-signature": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+          "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+          "dev": true
+        }
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/express": "^4.17.13",
     "@types/express-useragent": "^1.0.2",
     "@types/semver": "^7.3.9",
-    "@types/supertest": "^2.0.12",
+    "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "nanoid": "^3.3.6",
@@ -39,7 +39,7 @@
     "nodemon": "^2.0.16",
     "semantic-release": "^21.1.1",
     "sinon": "^14.0.0",
-    "supertest": "^6.2.3",
+    "supertest": "^7.2.2",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },

--- a/test/fixtures/builders.ts
+++ b/test/fixtures/builders.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import { GithubRelease, GithubReleaseAsset } from "../../src";
+import {
+  mock_github_asset,
+  mock_github_release,
+  MockGithubAssetOpts,
+} from "../nock/nockGithubListReleases";
+
+/**
+ * Composable fixture builders on top of the low-level test/nock mocks.
+ *
+ * The naming convention `app-<version>-<variant>.<ext>` matches what the
+ * platform-detection code in src/utils expects (see filenameToOperatingSystem,
+ * filenameToArchitecture, filenameToPackageFormat).
+ */
+
+export interface BuildReleaseOpts {
+  owner: string;
+  repo: string;
+  /** semver version, without the leading v (the tag gets `v` prefixed) */
+  version: string;
+  /** release notes body; defaults to "Notes for <version>" */
+  notes?: string | null;
+  assets: Partial<GithubReleaseAsset>[];
+  draft?: boolean;
+  prerelease?: boolean;
+  /** ISO timestamp; defaults to a deterministic date derived from the version */
+  published_at?: string;
+}
+
+/**
+ * Deterministic publish date so channel-latest logic (which compares
+ * published_at) can be asserted without millisecond races between mocks:
+ * days-since-epoch offset by major*10000 + minor*100 + patch.
+ */
+export function publishedAtForVersion(version: string): string {
+  const [major, minor, patch] = version
+    .split("-")[0]
+    .split(".")
+    .map((part) => parseInt(part, 10));
+  const days = major * 10000 + minor * 100 + patch;
+  const date = new Date(Date.UTC(2020, 0, 1) + days * 24 * 60 * 60 * 1000);
+  return date.toISOString();
+}
+
+export function buildRelease(opts: BuildReleaseOpts): Partial<GithubRelease> {
+  const notes = opts.notes === undefined ? `Notes for ${opts.version}` : opts.notes;
+  const published_at = opts.published_at ?? publishedAtForVersion(opts.version);
+  return mock_github_release(
+    opts.owner,
+    opts.repo,
+    `v${opts.version}`,
+    opts.assets,
+    opts.draft ?? false,
+    opts.prerelease ?? false,
+    notes,
+    published_at
+  );
+}
+
+export function buildAsset(
+  owner: string,
+  repo: string,
+  filename: string,
+  opts: MockGithubAssetOpts = {}
+): Partial<GithubReleaseAsset> {
+  return mock_github_asset(owner, repo, filename, opts);
+}
+
+/** macOS assets: dmg + zip for x64, arm64, and universal. */
+export function buildMacAssets(owner: string, repo: string, version: string) {
+  return [
+    buildAsset(owner, repo, `app-${version}-x64.dmg`),
+    buildAsset(owner, repo, `app-${version}-x64-mac.zip`),
+    buildAsset(owner, repo, `app-${version}-arm64.dmg`),
+    buildAsset(owner, repo, `app-${version}-arm64-mac.zip`),
+    buildAsset(owner, repo, `app-${version}-univ.dmg`),
+    buildAsset(owner, repo, `app-${version}-univ-mac.zip`),
+  ];
+}
+
+/** Windows assets: NSIS-style setup.exe + Squirrel full/delta nupkgs. */
+export function buildWindowsAssets(
+  owner: string,
+  repo: string,
+  version: string
+) {
+  return [
+    buildAsset(owner, repo, `app-${version}-x64-setup.exe`),
+    buildAsset(owner, repo, `app-${version}-x64-full.nupkg`, {
+      size: SQUIRREL_NUPKG_SIZE,
+    }),
+    buildAsset(owner, repo, `app-${version}-x64-delta.nupkg`, {
+      size: SQUIRREL_DELTA_SIZE,
+    }),
+  ];
+}
+
+/** Linux assets: tar.gz + deb + rpm, all x64. */
+export function buildLinuxAssets(owner: string, repo: string, version: string) {
+  return [
+    buildAsset(owner, repo, `app-${version}-linux-x64.tar.gz`),
+    buildAsset(owner, repo, `app-${version}-linux-x64.deb`),
+    buildAsset(owner, repo, `app-${version}-linux-x64.rpm`),
+  ];
+}
+
+/** Every platform + a Squirrel.Windows RELEASES asset. */
+export function buildFullPlatformAssets(
+  owner: string,
+  repo: string,
+  version: string
+) {
+  return [
+    ...buildMacAssets(owner, repo, version),
+    ...buildWindowsAssets(owner, repo, version),
+    ...buildLinuxAssets(owner, repo, version),
+    buildAsset(owner, repo, "RELEASES", {
+      size: 200,
+      content_type: "application/octet-stream",
+    }),
+  ];
+}
+
+/**
+ * Standard stable-only release set: 2.7.0 > 2.6.0 > 2.5.0, each with the
+ * full platform asset matrix. Use for download/update happy paths where a
+ * prerelease would change which version is "latest".
+ */
+export function buildStableReleaseSet(owner: string, repo: string) {
+  return ["2.7.0", "2.6.0", "2.5.0"].map((version) =>
+    buildRelease({
+      owner,
+      repo,
+      version,
+      assets: buildFullPlatformAssets(owner, repo, version),
+    })
+  );
+}
+
+/**
+ * Mixed-channel release set: the stable set plus 2.8.0-beta.1/2 on the beta
+ * channel. Note 2.8.0-beta.2 is the highest semver overall, which several
+ * routes surface when they resolve with channel "*".
+ */
+export function buildMixedChannelReleaseSet(owner: string, repo: string) {
+  const beta = ["2.8.0-beta.2", "2.8.0-beta.1"].map((version) =>
+    buildRelease({
+      owner,
+      repo,
+      version,
+      prerelease: true,
+      assets: buildFullPlatformAssets(owner, repo, version),
+    })
+  );
+  return [...beta, ...buildStableReleaseSet(owner, repo)];
+}
+
+// Sizes referenced by the RELEASES fixture below; kept in sync between the
+// asset mocks and the RELEASES file content.
+export const SQUIRREL_NUPKG_SIZE = 143940252;
+export const SQUIRREL_DELTA_SIZE = 1494002;
+
+export interface SquirrelReleasesEntry {
+  filename: string;
+  size: number;
+  sha?: string;
+}
+
+/** Deterministic fake SHA1 for a filename (40 hex chars, as Squirrel emits). */
+export function fakeSha1(filename: string): string {
+  return createHash("sha1").update(filename).digest("hex").toUpperCase();
+}
+
+/**
+ * Render Squirrel.Windows RELEASES file content:
+ * one `<SHA1> <filename> <size>` line per entry, LF separated, no BOM.
+ */
+export function buildRELEASESContent(entries: SquirrelReleasesEntry[]): string {
+  return entries
+    .map((e) => [e.sha ?? fakeSha1(e.filename), e.filename, e.size].join(" "))
+    .join("\n");
+}
+
+/** RELEASES content matching buildWindowsAssets(version): full + delta nupkg. */
+export function buildRELEASESContentForVersion(version: string): string {
+  return buildRELEASESContent([
+    {
+      filename: `app-${version}-x64-delta.nupkg`,
+      size: SQUIRREL_DELTA_SIZE,
+    },
+    {
+      filename: `app-${version}-x64-full.nupkg`,
+      size: SQUIRREL_NUPKG_SIZE,
+    },
+  ]);
+}

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1,0 +1,74 @@
+import express from "express";
+import nock from "nock";
+import { GithubRelease } from "../src";
+import { Pecans, PecansGitHubBackend, PecansOptions } from "../src";
+import { PecansGitHubBackendOpts } from "../src/backends/github";
+import { PecansAsset } from "../src/models";
+import { nockGithubListReleases } from "./nock/nockGithubListReleases";
+
+/**
+ * Shared integration-test harness. Backends are constructed from the
+ * env.test.sh variables (owner-nock-mocked / repo-nock-mocked) and all GitHub
+ * traffic is intercepted by nock.
+ */
+
+export function configurePecansGitHubBackend(
+  opts: PecansGitHubBackendOpts = {}
+) {
+  const env = PecansGitHubBackend.getEnvironment();
+  const backend = PecansGitHubBackend.FromEnv(env, opts);
+  return { env, backend };
+}
+
+export function configurePecansTestApp(
+  backend: PecansGitHubBackend,
+  opts: PecansOptions = {}
+) {
+  const pecans = new Pecans(backend, opts);
+  const app = express();
+  app.use(pecans.router);
+  return { pecans, app };
+}
+
+/**
+ * One-call setup: backend + app with the given releases already mocked on the
+ * GitHub list-releases endpoint.
+ */
+export function configureTestAppWithReleases(
+  releases: Partial<GithubRelease>[],
+  backendOpts: PecansGitHubBackendOpts = {},
+  pecansOpts: PecansOptions = {}
+) {
+  const { env, backend } = configurePecansGitHubBackend(backendOpts);
+  nockGithubListReleases(nock, env.GITHUB_OWNER, env.GITHUB_REPO, releases);
+  const { pecans, app } = configurePecansTestApp(backend, pecansOpts);
+  return { env, backend, pecans, app };
+}
+
+/**
+ * Look up a normalized asset by release version + filename, warming the
+ * backend cache (consumes the list-releases nock interceptor on first call;
+ * subsequent app requests share the cache).
+ */
+export async function findAsset(
+  backend: PecansGitHubBackend,
+  version: string,
+  filename: string
+): Promise<PecansAsset> {
+  const releases = await backend.releases();
+  const release = releases.getReleases().find((r) => r.version === version);
+  if (!release) throw new Error(`fixture release ${version} not found`);
+  const asset = release.assets.find((a) => a.filename === filename);
+  if (!asset)
+    throw new Error(`fixture asset ${filename} not found in ${version}`);
+  return asset;
+}
+
+/** Browser User-Agent strings for platform-detection tests. */
+export const USER_AGENTS = {
+  mac: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  windows:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  linux:
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+};

--- a/test/helpers/contracts.ts
+++ b/test/helpers/contracts.ts
@@ -3,6 +3,19 @@ import { expect } from "vitest";
 /**
  * Contract assertions for the protocols spoken by Electron's built-in
  * autoUpdater. These shapes are consumed by deployed apps and MUST NOT drift.
+ *
+ * Provenance: originally derived from pecans' handleUpdateOSX/handleUpdateWin
+ * output, then verified against the consumers:
+ * - Squirrel.Mac README, "Update JSON Format": only `url` is REQUIRED;
+ *   `name`, `notes`, `pub_date` are optional; `pub_date` must be ISO 8601
+ *   when present; 200 = update available, 204 = none; `url` must serve a ZIP
+ *   (fetched with `Accept: application/zip`).
+ *   https://github.com/Squirrel/Squirrel.Mac#update-json-format
+ * - Squirrel.Windows ReleaseEntry.cs: RELEASES lines parse with
+ *   `^([0-9a-fA-F]{40})\s+(\S+)\s+(\d+)[\r]*$` (SHA1 case-insensitive);
+ *   absolute HTTP(S) URLs in the filename field are explicitly supported
+ *   (Utility.IsHttpUrl); delta packages end with `-delta.nupkg`.
+ *   https://github.com/Squirrel/Squirrel.Windows/blob/develop/src/Squirrel/ReleaseEntry.cs
  */
 
 export interface SquirrelMacUpdate {
@@ -13,36 +26,53 @@ export interface SquirrelMacUpdate {
 }
 
 /**
- * Squirrel.Mac update response: exactly {url, name, notes, pub_date}, where
- * url points at a zip download and pub_date is ISO 8601.
+ * Squirrel.Mac update response.
+ *
+ * The client contract requires only a well-formed `url` (and ISO 8601
+ * `pub_date` when present). The exact-key-set check below is a stricter pin
+ * on pecans' own output, to detect drift in what we emit - not a client
+ * requirement.
  */
 export function expectSquirrelMacResponse(
   body: unknown
 ): asserts body is SquirrelMacUpdate {
+  // explicit null guard: typeof null is also "object"
+  expect(body).not.toBeNull();
   expect(body).toBeTypeOf("object");
   const update = body as Record<string, unknown>;
-  // exact key set - additive drift breaks nothing but signals contract change,
-  // missing keys break Squirrel.Mac clients.
+
+  // client-required: url must be present and well-formed
+  expect(update.url).toBeTypeOf("string");
+  expect(() => new URL(update.url as string)).not.toThrow();
+
+  // client-required when present: ISO 8601 pub_date
+  expect(update.pub_date).toBeTypeOf("string");
+  expect(new Date(update.pub_date as string).toISOString()).toBe(
+    update.pub_date
+  );
+
+  // pecans-output pin: we always emit exactly these four keys
   expect(Object.keys(update).sort()).toEqual([
     "name",
     "notes",
     "pub_date",
     "url",
   ]);
-  expect(update.url).toBeTypeOf("string");
   expect(update.name).toBeTypeOf("string");
   expect(update.notes).toBeTypeOf("string");
-  expect(update.pub_date).toBeTypeOf("string");
-  expect(new Date(update.pub_date as string).toISOString()).toBe(
-    update.pub_date
-  );
 }
 
-const RELEASES_LINE = /^[0-9a-fA-F]{40} \S+ \d+$/;
+// Exact parse regex from Squirrel.Windows ReleaseEntry.cs (sans trailing
+// [\r]*, which we forbid outright below).
+const SQUIRREL_WINDOWS_LINE = /^([0-9a-fA-F]{40})\s+(\S+)\s+(\d+)$/;
+
+// pecans-output pin: we emit single-space separators (consumer accepts \s+)
+const PECANS_LINE = /^[0-9a-fA-F]{40} \S+ \d+$/;
 
 /**
  * Squirrel.Windows RELEASES contract: LF-separated `<SHA1> <url> <size>`
- * lines, no BOM, no CR, filenames rewritten to absolute /dl/ URLs.
+ * lines, no BOM, no CR, filenames rewritten to absolute /dl/ URLs (absolute
+ * URLs are supported by the client's parser).
  */
 export function expectRELEASESFormat(text: string) {
   expect(text.charCodeAt(0)).not.toBe(0xfeff); // no BOM
@@ -50,7 +80,10 @@ export function expectRELEASESFormat(text: string) {
   const lines = text.split("\n");
   expect(lines.length).toBeGreaterThan(0);
   for (const line of lines) {
-    expect(line).toMatch(RELEASES_LINE);
+    // must parse with the consumer's own regex...
+    expect(line).toMatch(SQUIRREL_WINDOWS_LINE);
+    // ...and match the tighter format pecans emits
+    expect(line).toMatch(PECANS_LINE);
     const url = line.split(" ")[1];
     expect(url).toMatch(/^https?:\/\/[^/]+(\/.*)?\/dl\/[^/ ]+$/);
   }

--- a/test/helpers/contracts.ts
+++ b/test/helpers/contracts.ts
@@ -1,0 +1,57 @@
+import { expect } from "vitest";
+
+/**
+ * Contract assertions for the protocols spoken by Electron's built-in
+ * autoUpdater. These shapes are consumed by deployed apps and MUST NOT drift.
+ */
+
+export interface SquirrelMacUpdate {
+  url: string;
+  name: string;
+  notes: string;
+  pub_date: string;
+}
+
+/**
+ * Squirrel.Mac update response: exactly {url, name, notes, pub_date}, where
+ * url points at a zip download and pub_date is ISO 8601.
+ */
+export function expectSquirrelMacResponse(
+  body: unknown
+): asserts body is SquirrelMacUpdate {
+  expect(body).toBeTypeOf("object");
+  const update = body as Record<string, unknown>;
+  // exact key set - additive drift breaks nothing but signals contract change,
+  // missing keys break Squirrel.Mac clients.
+  expect(Object.keys(update).sort()).toEqual([
+    "name",
+    "notes",
+    "pub_date",
+    "url",
+  ]);
+  expect(update.url).toBeTypeOf("string");
+  expect(update.name).toBeTypeOf("string");
+  expect(update.notes).toBeTypeOf("string");
+  expect(update.pub_date).toBeTypeOf("string");
+  expect(new Date(update.pub_date as string).toISOString()).toBe(
+    update.pub_date
+  );
+}
+
+const RELEASES_LINE = /^[0-9a-fA-F]{40} \S+ \d+$/;
+
+/**
+ * Squirrel.Windows RELEASES contract: LF-separated `<SHA1> <url> <size>`
+ * lines, no BOM, no CR, filenames rewritten to absolute /dl/ URLs.
+ */
+export function expectRELEASESFormat(text: string) {
+  expect(text.charCodeAt(0)).not.toBe(0xfeff); // no BOM
+  expect(text).not.toContain("\r");
+  const lines = text.split("\n");
+  expect(lines.length).toBeGreaterThan(0);
+  for (const line of lines) {
+    expect(line).toMatch(RELEASES_LINE);
+    const url = line.split(" ")[1];
+    expect(url).toMatch(/^https?:\/\/[^/]+(\/.*)?\/dl\/[^/ ]+$/);
+  }
+}

--- a/test/integration/api.spec.ts
+++ b/test/integration/api.spec.ts
@@ -1,0 +1,177 @@
+import nock from "nock";
+import supertest from "supertest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildMixedChannelReleaseSet,
+  buildStableReleaseSet,
+} from "../fixtures/builders";
+import { configureTestAppWithReleases } from "../harness";
+
+nock.disableNetConnect();
+nock.enableNetConnect(/(localhost|127\.0\.0\.1)/);
+
+const OWNER = process.env.GITHUB_OWNER as string;
+const REPO = process.env.GITHUB_REPO as string;
+
+describe("/api/channels", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("lists the stable channel with its latest version", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/api/channels").expect(200);
+    expect(res.body).toHaveLength(1);
+    const [stable] = res.body;
+    expect(stable.name).toBe("stable");
+    expect(stable.latest).toBe("2.7.0");
+    expect(stable.versions_count).toBe(3);
+  });
+
+  it("lists every channel when prereleases exist", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/api/channels").expect(200);
+    const names = res.body.map((c: { name: string }) => c.name).sort();
+    expect(names).toEqual(["beta", "stable"]);
+    const beta = res.body.find((c: { name: string }) => c.name === "beta");
+    expect(beta.versions_count).toBe(2);
+  });
+});
+
+describe("/api/versions", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("lists all releases sorted by version descending", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/api/versions").expect(200);
+    const versions = res.body.map((r: { version: string }) => r.version);
+    expect(versions).toEqual(["2.7.0", "2.6.0", "2.5.0"]);
+  });
+
+  it("?channel filters to that channel", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/api/versions?channel=beta")
+      .expect(200);
+    const versions = res.body.map((r: { version: string }) => r.version);
+    expect(versions).toEqual(["2.8.0-beta.2", "2.8.0-beta.1"]);
+  });
+
+  it("?version=latest collapses to the newest release", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/api/versions?version=latest")
+      .expect(200);
+    const versions = res.body.map((r: { version: string }) => r.version);
+    expect(versions).toEqual(["2.7.0"]);
+  });
+
+  it("?version=<range> filters by semver range", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/api/versions?version=%3E%3D2.6.0") // >=2.6.0
+      .expect(200);
+    const versions = res.body.map((r: { version: string }) => r.version);
+    expect(versions).toEqual(["2.7.0", "2.6.0"]);
+  });
+
+  it("?platform filters to releases with assets for that platform", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/api/versions?platform=osx_64")
+      .expect(200);
+    expect(res.body).toHaveLength(3);
+  });
+
+  it("silently ignores an unknown platform value", async () => {
+    // getPlatformFromQuery returns undefined for junk, so no filter applies
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/api/versions?platform=amiga")
+      .expect(200);
+    expect(res.body).toHaveLength(3);
+  });
+
+  it("returns an empty list for an unknown channel", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/api/versions?channel=nightly")
+      .expect(200);
+    expect(res.body).toEqual([]);
+  });
+});
+
+describe("/api/status", () => {
+  afterEach(() => nock.cleanAll());
+
+  // handleApiStatus exists but is not routed; Phase 2 wires it to /api/status
+  it.fails("reports uptime (intended - wired in Phase 2)", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/api/status").expect(200);
+    expect(res.body.uptime).toBeTypeOf("number");
+  });
+});
+
+describe("/notes", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("returns the latest release's notes by default", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/notes")
+      .set("Accept", "application/json")
+      .expect(200);
+    expect(res.body).toEqual({ note: "## 2.7.0\n\nNotes for 2.7.0\n" });
+  });
+
+  it("?version returns that release's notes", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/notes?version=2.6.0")
+      .set("Accept", "application/json")
+      .expect(200);
+    expect(res.body).toEqual({ note: "## 2.6.0\n\nNotes for 2.6.0\n" });
+  });
+
+  it("serves plain text when json is not requested", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/notes?version=2.6.0")
+      .set("Accept", "text/plain")
+      .expect(200);
+    expect(res.text).toBe("## 2.6.0\n\nNotes for 2.6.0\n");
+  });
+
+  // Today an unknown version crashes formatReleaseNote (undefined release)
+  // -> 500. Phase 6 turns this into a 404.
+  it("500s for an unknown version (until typed error handling lands)", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/notes?version=99.0.0").expect(500);
+  });
+});

--- a/test/integration/dl.spec.ts
+++ b/test/integration/dl.spec.ts
@@ -1,0 +1,175 @@
+import nock from "nock";
+import supertest from "supertest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildMixedChannelReleaseSet,
+  buildStableReleaseSet,
+} from "../fixtures/builders";
+import { configureTestAppWithReleases, findAsset } from "../harness";
+import { nockGithubReleasesAssetRedirect } from "../nock/nockGithubReleaseAsset";
+
+nock.disableNetConnect();
+nock.enableNetConnect(/(localhost|127\.0\.0\.1)/);
+
+const OWNER = process.env.GITHUB_OWNER as string;
+const REPO = process.env.GITHUB_REPO as string;
+
+describe("/dl/:os/:arch", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  // Table of happy paths: os/arch (+query) -> expected asset of the latest
+  // stable release (2.7.0).
+  const cases: [string, string][] = [
+    ["/dl/osx/64", "app-2.7.0-x64.dmg"],
+    ["/dl/osx/arm64", "app-2.7.0-arm64.dmg"],
+    ["/dl/osx/universal", "app-2.7.0-univ.dmg"],
+    ["/dl/windows/64", "app-2.7.0-x64-setup.exe"],
+    ["/dl/linux/64?pkg=deb", "app-2.7.0-linux-x64.deb"],
+    ["/dl/linux/64?pkg=rpm", "app-2.7.0-linux-x64.rpm"],
+  ];
+
+  it.each(cases)("%s redirects to %s", async (url, filename) => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", filename);
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    const res = await supertest(app).get(url).expect(302);
+    expect(res.headers.location).toContain(filename);
+  });
+
+  // BUG (fix in Phase 2): PecansAsset.satisfiesExtensions uses path.extname,
+  // which yields ".gz" for ".tar.gz" filenames, so a plain /dl/linux/64
+  // request can never match a .tar.gz asset. getSupportedExt() already handles
+  // the double extension and should be used instead.
+  it.fails("/dl/linux/64 redirects to the tar.gz asset (intended)", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(
+      backend,
+      "2.7.0",
+      "app-2.7.0-linux-x64.tar.gz"
+    );
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    const res = await supertest(app).get("/dl/linux/64").expect(302);
+    expect(res.headers.location).toContain("app-2.7.0-linux-x64.tar.gz");
+  });
+
+  it("/dl/linux/64 currently 404s on a .tar.gz-only fixture (see bug above)", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/dl/linux/64").expect(404);
+    expect(res.text).toContain("No Matching Assets Found");
+  });
+
+  it("?version selects an older release", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.6.0", "app-2.6.0-x64.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    const res = await supertest(app)
+      .get("/dl/osx/64?version=2.6.0")
+      .expect(302);
+    expect(res.headers.location).toContain("app-2.6.0-x64.dmg");
+  });
+
+  it("?channel=beta selects the latest beta release", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(
+      backend,
+      "2.8.0-beta.2",
+      "app-2.8.0-beta.2-x64.dmg"
+    );
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    const res = await supertest(app)
+      .get("/dl/osx/64?channel=beta")
+      .expect(302);
+    expect(res.headers.location).toContain("app-2.8.0-beta.2-x64.dmg");
+  });
+
+  it("defaults to the stable channel when prereleases exist", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-x64.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    const res = await supertest(app).get("/dl/osx/64").expect(302);
+    expect(res.headers.location).toContain("app-2.7.0-x64.dmg");
+  });
+
+  it("404s on an unrecognized os", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/dl/freebsd/64").expect(404);
+    expect(res.text).toContain("Unrecognized OS");
+  });
+
+  it("404s on an unsupported arch for the os", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/dl/linux/arm64").expect(404);
+    expect(res.text).toContain("Unsupported Arch");
+  });
+
+  it("404s when no release matches the version", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/dl/osx/64?version=99.0.0")
+      .expect(404);
+    expect(res.text).toContain("No Matching Releases Found");
+  });
+
+  it("404s when no asset matches the os/arch", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    // windows 32-bit assets are not part of the fixture
+    await supertest(app).get("/dl/windows/32").expect(404);
+  });
+
+  // Today an unknown channel throws a plain Error -> express default 500.
+  // Phase 6 (typed errors) will turn this into a 4xx.
+  it("500s on an unknown channel (until typed error handling lands)", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/dl/osx/64?channel=nightly").expect(500);
+  });
+});
+
+describe("/dl/:filename", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("redirects to the asset with that filename", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.6.0", "app-2.6.0-x64-full.nupkg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    const res = await supertest(app)
+      .get("/dl/app-2.6.0-x64-full.nupkg")
+      .expect(302);
+    expect(res.headers.location).toContain("app-2.6.0-x64-full.nupkg");
+  });
+
+  it("404s for a filename that matches no asset", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/dl/no-such-file.dmg").expect(404);
+    expect(res.text).toContain("not found");
+  });
+});

--- a/test/integration/download.spec.ts
+++ b/test/integration/download.spec.ts
@@ -1,0 +1,350 @@
+import nock from "nock";
+import supertest from "supertest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildMixedChannelReleaseSet,
+  buildStableReleaseSet,
+} from "../fixtures/builders";
+import {
+  configureTestAppWithReleases,
+  findAsset,
+  USER_AGENTS,
+} from "../harness";
+import { nockGithubReleasesAssetRedirect } from "../nock/nockGithubReleaseAsset";
+
+nock.disableNetConnect();
+nock.enableNetConnect(/(localhost|127\.0\.0\.1)/);
+
+const OWNER = process.env.GITHUB_OWNER as string;
+const REPO = process.env.GITHUB_REPO as string;
+
+async function expectRedirectTo(
+  app: Parameters<typeof supertest>[0],
+  url: string,
+  filename: string,
+  ua?: string
+) {
+  let request = supertest(app).get(url);
+  if (ua) request = request.set("User-Agent", ua);
+  const res = await request.expect(302);
+  expect(res.headers.location).toContain(filename);
+  return res;
+}
+
+describe("GET / (user-agent driven download)", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("serves the universal dmg to a mac browser", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(app, "/", "app-2.7.0-univ.dmg", USER_AGENTS.mac);
+  });
+
+  it("serves the setup exe to a windows browser", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-x64-setup.exe");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/",
+      "app-2.7.0-x64-setup.exe",
+      USER_AGENTS.windows
+    );
+  });
+
+  // Linux resolution sorts composite platform ids by string length, so the
+  // longer "linux_deb_64" beats "linux_64" and a .deb is served to browsers.
+  it("serves the deb to a linux browser", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-linux-x64.deb");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/",
+      "app-2.7.0-linux-x64.deb",
+      USER_AGENTS.linux
+    );
+  });
+
+  // Today an unresolvable platform throws a plain Error -> 500.
+  it("500s when the platform cannot be determined", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/").set("User-Agent", "curl/8.0").expect(500);
+  });
+});
+
+describe("/download/:platform?", () => {
+  afterEach(() => nock.cleanAll());
+
+  const aliasCases: [string, string][] = [
+    // canonical composite ids
+    ["osx_64", "app-2.7.0-univ.dmg"], // universal preferred over x64
+    ["windows_64", "app-2.7.0-x64-setup.exe"],
+    // legacy aliases still used by deployed apps
+    ["darwin", "app-2.7.0-univ.dmg"],
+    ["mac-arm64", "app-2.7.0-univ.dmg"], // universal preferred over arm64
+    ["win-x64", "app-2.7.0-x64-setup.exe"],
+  ];
+
+  it.each(aliasCases)(
+    "/download/%s redirects to %s",
+    async (platform, filename) => {
+      const { app, backend } = configureTestAppWithReleases(
+        buildStableReleaseSet(OWNER, REPO)
+      );
+      const asset = await findAsset(backend, "2.7.0", filename);
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+      await expectRedirectTo(app, `/download/${platform}`, filename);
+    }
+  );
+
+  it("serves the platform build when preferUniversal is off", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+      {},
+      { preferUniversal: false }
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-arm64.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(app, "/download/mac-arm64", "app-2.7.0-arm64.dmg");
+  });
+
+  it("?filetype=zip prefers the zip build", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ-mac.zip");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/download/osx?filetype=zip",
+      "app-2.7.0-univ-mac.zip"
+    );
+  });
+
+  it("?tag=<version> serves that version", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.6.0", "app-2.6.0-univ.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/download/osx?tag=2.6.0",
+      "app-2.6.0-univ.dmg"
+    );
+  });
+
+  it("?tag=latest serves the latest stable release", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/download/osx?tag=latest",
+      "app-2.7.0-univ.dmg"
+    );
+  });
+
+  // BUG (fix in Phase 2): when no tag is given, handleDownload widens the
+  // channel to "*" (the `tag != "latest"` check is true for undefined), so
+  // the newest release of ANY channel wins and stable users receive
+  // prereleases.
+  it.fails(
+    "/download/osx without a tag serves the latest STABLE release (intended)",
+    async () => {
+      const { app, backend } = configureTestAppWithReleases(
+        buildMixedChannelReleaseSet(OWNER, REPO)
+      );
+      const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+      // also mock the asset today's buggy resolution serves, so the request
+      // completes and the assertion fails fast instead of timing out
+      const actual = await findAsset(
+        backend,
+        "2.8.0-beta.2",
+        "app-2.8.0-beta.2-univ.dmg"
+      );
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, actual);
+      await expectRedirectTo(app, "/download/osx", "app-2.7.0-univ.dmg");
+    }
+  );
+
+  // README advertises /download/latest but "latest" parses as a platform and
+  // 500s. Phase 2 aligns the README with the real route surface.
+  it("500s on /download/latest (unsupported route shape)", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app)
+      .get("/download/latest")
+      .set("User-Agent", USER_AGENTS.mac)
+      .expect(500);
+  });
+
+  it("500s on an unknown platform", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/download/amiga").expect(500);
+  });
+
+  it("500s when no asset exists for the platform", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    // fixture has no 32-bit windows assets
+    await supertest(app).get("/download/win32").expect(500);
+  });
+});
+
+describe("/download/channel/:channel/:platform?", () => {
+  afterEach(() => nock.cleanAll());
+
+  // BUG (fix in Phase 2): handleDownload reads the channel from the query
+  // string only; req.params.channel from this route is ignored, so the
+  // channel segment has no effect.
+  it.fails(
+    "/download/channel/stable/osx serves the latest stable release (intended)",
+    async () => {
+      const { app, backend } = configureTestAppWithReleases(
+        buildMixedChannelReleaseSet(OWNER, REPO)
+      );
+      const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+      // see note above: mock the wrongly-served beta asset to fail fast
+      const actual = await findAsset(
+        backend,
+        "2.8.0-beta.2",
+        "app-2.8.0-beta.2-univ.dmg"
+      );
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, actual);
+      await expectRedirectTo(
+        app,
+        "/download/channel/stable/osx",
+        "app-2.7.0-univ.dmg"
+      );
+    }
+  );
+
+  it("serves the latest beta via the beta channel route", async () => {
+    // passes today only because channel "*" resolves to the beta, which is
+    // the highest semver overall - not because the path channel is honored.
+    const { app, backend } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(
+      backend,
+      "2.8.0-beta.2",
+      "app-2.8.0-beta.2-univ.dmg"
+    );
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/download/channel/beta/osx",
+      "app-2.8.0-beta.2-univ.dmg"
+    );
+  });
+});
+
+describe("/download/:tag/:filename", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("serves a file that belongs to the latest release", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-x64.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/download/2.7.0/app-2.7.0-x64.dmg",
+      "app-2.7.0-x64.dmg"
+    );
+  });
+
+  // BUG (fix in Phase 2): handleDownload never reads req.params.tag - the tag
+  // comes from the query string only - so files from anything but the newest
+  // release cannot be downloaded through this route.
+  it.fails(
+    "serves a file from an older release by its tag segment (intended)",
+    async () => {
+      const { app, backend } = configureTestAppWithReleases(
+        buildStableReleaseSet(OWNER, REPO)
+      );
+      const asset = await findAsset(backend, "2.6.0", "app-2.6.0-x64.dmg");
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+      await expectRedirectTo(
+        app,
+        "/download/2.6.0/app-2.6.0-x64.dmg",
+        "app-2.6.0-x64.dmg"
+      );
+    }
+  );
+});
+
+describe("/download/version/:tag/:platform?", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("serves the requested platform for the latest version", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/download/version/2.7.0/osx",
+      "app-2.7.0-univ.dmg"
+    );
+  });
+
+  // BUG (fix in Phase 2): req.params.tag is ignored, so this route always
+  // resolves the newest release regardless of the version segment.
+  it.fails("serves the version named in the path (intended)", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.6.0", "app-2.6.0-univ.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    // see note above: mock the wrongly-served latest asset to fail fast
+    const actual = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, actual);
+    await expectRedirectTo(
+      app,
+      "/download/version/2.6.0/osx",
+      "app-2.6.0-univ.dmg"
+    );
+  });
+
+  // BUG (fix in Phase 2): without the platform segment this path is shadowed
+  // by /download/:tag/:filename ("version" parses as the tag), which 500s.
+  // Intended: fall back to user-agent platform detection.
+  it.fails(
+    "falls back to user-agent detection without a platform segment (intended)",
+    async () => {
+      const { app, backend } = configureTestAppWithReleases(
+        buildStableReleaseSet(OWNER, REPO)
+      );
+      const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+      await expectRedirectTo(
+        app,
+        "/download/version/2.7.0",
+        "app-2.7.0-univ.dmg",
+        USER_AGENTS.mac
+      );
+    }
+  );
+});

--- a/test/integration/integration.spec.ts
+++ b/test/integration/integration.spec.ts
@@ -1,64 +1,30 @@
-import express from "express";
 import { describe, it, expect, afterEach } from "vitest";
 import nock from "nock";
 import supertest from "supertest";
-import { Pecans, PecansGitHubBackend } from "../../src";
 import {
   mockTypicalReleases,
   nockGithubListReleases,
   nockGithubListReleasesPaginated,
 } from "../nock/nockGithubListReleases";
 import { nockGithubReleasesAssetRedirect } from "../nock/nockGithubReleaseAsset";
+import {
+  configurePecansGitHubBackend,
+  configurePecansTestApp,
+} from "../harness";
 
 // nock.recorder.rec();
 nock.disableNetConnect();
 // Allow localhost connections so we can test local routes and mock servers.
 nock.enableNetConnect(/(localhost|127\.0\.0\.1)/);
 
-function configurePecansGitHubBackend() {
-  const env = PecansGitHubBackend.getEnvironment();
-  const backend = PecansGitHubBackend.FromEnv(env);
-  return { env, backend };
-}
-
-function configurePecansTestApp(backend: PecansGitHubBackend) {
-  const pecans = new Pecans(backend);
-  const app = express();
-  app.use(pecans.router);
-  return { pecans, app };
-}
-
-// function testDownload(os: OperatingSystem, arch: Architecture): void {
-//   it("version defaults to latest and channel defaults to stable", async () => {
-//     const { env, backend } = configurePecansGitHubBackend();
-//     nockGithubListReleases(nock, env.GITHUB_OWNER, env.GITHUB_REPO);
-//     const { app } = configurePecansTestApp(backend);
-//     const response = await supertest(app).get(`/dl/${os}/${arch}`).expect(302);
-//     // test against latest known version. This will need to be changed to match the mock data.
-//     assert.match(response.header.location, /2\.7\.0/);
-//   });
-
-//   describe("version query", () => {
-//     it("given a version, when that version exists, it returns that version", async () => {});
-//     it("given a version, when that version does not exist, it returns a 404", async () => {});
-//   });
-
-//   describe("channel query", () => {
-//     it("is not currently supported, it might or might not work.", async () => {});
-//   });
-// }
-
 describe("Integration Tests: Github Backend", () => {
   afterEach(() => {
     nock.cleanAll();
   });
 
-  // TODO: Implement tests for deprecated endpoints when needed
-  // describe("deprecated endpoints", () => {
-  //   describe("/download/:platform?", () => {});
-  //   describe("/update/:platform/:version", () => {});
-  //   describe("/update/:platform/:version/RELEASES", () => {});
-  // });
+  // Route-level coverage lives in the sibling specs:
+  // download.spec.ts, dl.spec.ts, update-mac.spec.ts, update-win.spec.ts,
+  // api.spec.ts, webhook.spec.ts
 
   // Regression test for the node-fetch@2 override bug: octokit.paginate() must
   // walk every page (via the `Link: rel="next"` header) and return the union of
@@ -88,8 +54,6 @@ describe("Integration Tests: Github Backend", () => {
     });
   });
 
-  // TODO: Implement webhook refresh tests
-  // describe("/webhook/refresh", () => {});
   describe("/dl/:filename", () => {
     it("requires filename", async () => {
       const { env, backend } = configurePecansGitHubBackend();
@@ -115,22 +79,4 @@ describe("Integration Tests: Github Backend", () => {
       expect(reponse.headers.location).toMatch(new RegExp(`${filename}`));
     });
   });
-  // TODO: Implement tests for OS/arch specific downloads
-  // describe("/dl/:os/:arch", () => {
-  //   describe("/dl/windows/x64", () => {});
-  //   describe("/dl/osx/x64", () => {});
-  //   describe("/dl/osx/arm64", () => {});
-  //   describe("/dl/osx/universal", () => {});
-  //   describe("/dl/linux/x64", () => {});
-  //   describe("/dl/linux/arm64", () => {});
-  // });
-
-  // TODO: Implement API endpoint tests
-  // describe("/api", () => {
-  //   describe("/api/channels", () => {});
-  //   describe("/api/versions", () => {});
-  // });
-
-  // TODO: Implement notes endpoint tests
-  // describe("/notes/:version?", () => {});
 });

--- a/test/integration/update-mac.spec.ts
+++ b/test/integration/update-mac.spec.ts
@@ -1,0 +1,146 @@
+import nock from "nock";
+import supertest from "supertest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildMixedChannelReleaseSet,
+  buildStableReleaseSet,
+  publishedAtForVersion,
+} from "../fixtures/builders";
+import { configureTestAppWithReleases, findAsset } from "../harness";
+import { expectSquirrelMacResponse } from "../helpers/contracts";
+import { nockGithubReleasesAssetRedirect } from "../nock/nockGithubReleaseAsset";
+
+nock.disableNetConnect();
+nock.enableNetConnect(/(localhost|127\.0\.0\.1)/);
+
+const OWNER = process.env.GITHUB_OWNER as string;
+const REPO = process.env.GITHUB_REPO as string;
+
+// Squirrel.Mac contract (Electron built-in autoUpdater on macOS):
+// 204 = no update; 200 + {url, name, notes, pub_date} = update available.
+describe("/update/:platform/:version (Squirrel.Mac)", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("204s when the client is on the latest version", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/update/osx/2.7.0").expect(204);
+  });
+
+  it("204s when the client is ahead of every release", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/update/osx/999.0.0").expect(204);
+  });
+
+  it("200s with the update descriptor when behind", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/update/osx/2.5.0").expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.name).toBe("2.7.0");
+    expect(res.body.url).toMatch(
+      /\/download\/version\/2\.7\.0\/osx_64\?filetype=zip$/
+    );
+    expect(res.body.pub_date).toBe(publishedAtForVersion("2.7.0"));
+    // notes aggregate every version newer than the client, newest first,
+    // excluding the client's own version
+    expect(res.body.notes).toBe("Notes for 2.7.0\nNotes for 2.6.0\n");
+  });
+
+  it("accepts legacy platform aliases like darwin", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/update/darwin/2.6.0").expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.name).toBe("2.7.0");
+  });
+
+  it("the update url resolves to a zip download", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app).get("/update/osx/2.5.0").expect(200);
+    expectSquirrelMacResponse(res.body);
+    const path = new URL(res.body.url).pathname + new URL(res.body.url).search;
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ-mac.zip");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    const download = await supertest(app).get(path).expect(302);
+    expect(download.headers.location).toContain(".zip");
+  });
+
+  it("ignores prereleases for clients on the stable channel", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    // 2.8.0-beta.2 exists and is higher, but stable clients stay on 2.7.0
+    await supertest(app).get("/update/osx/2.7.0").expect(204);
+  });
+
+  it("500s on an unknown platform", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/update/amiga/2.5.0").expect(500);
+  });
+
+  it("500s on an invalid version", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/update/osx/not-a-version").expect(500);
+  });
+});
+
+describe("/update/channel/:channel/:platform/:version (Squirrel.Mac)", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("serves updates from the named channel", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/update/channel/beta/osx/2.8.0-beta.1")
+      .expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.name).toBe("2.8.0-beta.2");
+    expect(res.body.url).toMatch(
+      /\/download\/version\/2\.8\.0-beta\.2\/osx_64\?filetype=zip$/
+    );
+  });
+
+  it("204s when the client is on the latest channel version", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    await supertest(app)
+      .get("/update/channel/beta/osx/2.8.0-beta.2")
+      .expect(204);
+  });
+});
+
+describe("/update (deprecated redirect)", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("redirects to /update/:platform/:version", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const res = await supertest(app)
+      .get("/update?platform=osx&version=2.5.0")
+      .expect(302);
+    expect(res.headers.location).toBe("/update/osx/2.5.0");
+  });
+
+  it("500s when version or platform is missing", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/update?platform=osx").expect(500);
+    await supertest(app).get("/update?version=2.5.0").expect(500);
+  });
+});

--- a/test/integration/update-win.spec.ts
+++ b/test/integration/update-win.spec.ts
@@ -1,0 +1,169 @@
+import nock from "nock";
+import supertest from "supertest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildFullPlatformAssets,
+  buildRelease,
+  buildRELEASESContentForVersion,
+  buildStableReleaseSet,
+  buildMixedChannelReleaseSet,
+  fakeSha1,
+  SQUIRREL_DELTA_SIZE,
+  SQUIRREL_NUPKG_SIZE,
+} from "../fixtures/builders";
+import { configureTestAppWithReleases, findAsset } from "../harness";
+import { expectRELEASESFormat } from "../helpers/contracts";
+import { nockGithubAssetContent } from "../nock/nockGithubAssetContent";
+import { nockGithubReleasesAssetRedirect } from "../nock/nockGithubReleaseAsset";
+
+nock.disableNetConnect();
+nock.enableNetConnect(/(localhost|127\.0\.0\.1)/);
+
+const OWNER = process.env.GITHUB_OWNER as string;
+const REPO = process.env.GITHUB_REPO as string;
+
+/**
+ * RELEASES is served as application/octet-stream, which superagent buffers
+ * as a binary body rather than text.
+ */
+function bodyText(res: { body: unknown; text?: string }): string {
+  if (Buffer.isBuffer(res.body)) return res.body.toString("utf-8");
+  return res.text ?? "";
+}
+
+// Squirrel.Windows contract (Electron built-in autoUpdater on Windows):
+// the RELEASES file of the latest matching release is served with filenames
+// rewritten to absolute /dl/ URLs; the client then downloads the nupkgs.
+describe("/update/:platform/:version/RELEASES (Squirrel.Windows)", () => {
+  afterEach(() => nock.cleanAll());
+
+  async function setupReleasesRequest(
+    releases = buildStableReleaseSet(OWNER, REPO),
+    latest = "2.7.0"
+  ) {
+    const { app, backend } = configureTestAppWithReleases(releases);
+    const releasesAsset = await findAsset(backend, latest, "RELEASES");
+    nockGithubAssetContent(
+      nock,
+      OWNER,
+      REPO,
+      releasesAsset,
+      buildRELEASESContentForVersion(latest)
+    );
+    return { app, backend };
+  }
+
+  it("serves the latest RELEASES rewritten to /dl/ urls", async () => {
+    const { app } = await setupReleasesRequest();
+    const res = await supertest(app)
+      .get("/update/windows_64/2.5.0/RELEASES")
+      .expect(200);
+
+    const text = bodyText(res);
+    expectRELEASESFormat(text);
+
+    const lines = text.split("\n");
+    expect(lines).toHaveLength(2); // delta + full entries both preserved
+    const [deltaLine, fullLine] = lines;
+
+    // sha and size are passed through untouched; filename becomes an
+    // absolute URL on the requesting host
+    expect(deltaLine).toBe(
+      `${fakeSha1("app-2.7.0-x64-delta.nupkg")} ` +
+        `${urlOf(res, "app-2.7.0-x64-delta.nupkg")} ${SQUIRREL_DELTA_SIZE}`
+    );
+    expect(fullLine).toBe(
+      `${fakeSha1("app-2.7.0-x64-full.nupkg")} ` +
+        `${urlOf(res, "app-2.7.0-x64-full.nupkg")} ${SQUIRREL_NUPKG_SIZE}`
+    );
+
+    // headers Squirrel.Windows relies on
+    expect(res.headers["content-length"]).toBe(String(text.length));
+    expect(res.headers["content-disposition"]).toContain("RELEASES");
+  });
+
+  function urlOf(res: unknown, filename: string) {
+    // supertest binds an ephemeral host:port; recover it from the request
+    const host = (res as { request: { host: string } }).request.host;
+    return `http://${host}/dl/${filename}`;
+  }
+
+  it("serves RELEASES via the legacy win-x64 alias", async () => {
+    const { app } = await setupReleasesRequest();
+    const res = await supertest(app)
+      .get("/update/win-x64/2.5.0/RELEASES")
+      .expect(200);
+    expectRELEASESFormat(bodyText(res));
+  });
+
+  it("still serves RELEASES when the client is current", async () => {
+    const { app } = await setupReleasesRequest();
+    const res = await supertest(app)
+      .get("/update/windows_64/2.7.0/RELEASES")
+      .expect(200);
+    expectRELEASESFormat(bodyText(res));
+  });
+
+  it("the rewritten nupkg url downloads via 302", async () => {
+    const { app, backend } = await setupReleasesRequest();
+    const res = await supertest(app)
+      .get("/update/windows_64/2.5.0/RELEASES")
+      .expect(200);
+    const fullUrl = bodyText(res).split("\n")[1].split(" ")[1];
+    const path = new URL(fullUrl).pathname;
+
+    const nupkg = await findAsset(backend, "2.7.0", "app-2.7.0-x64-full.nupkg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, nupkg);
+    const download = await supertest(app).get(path).expect(302);
+    expect(download.headers.location).toContain("app-2.7.0-x64-full.nupkg");
+  });
+
+  it("serves the channel's RELEASES via the channel route", async () => {
+    const { app } = await setupReleasesRequest(
+      buildMixedChannelReleaseSet(OWNER, REPO),
+      "2.8.0-beta.2"
+    );
+    const res = await supertest(app)
+      .get("/update/channel/beta/windows_64/2.8.0-beta.1/RELEASES")
+      .expect(200);
+    const text = bodyText(res);
+    expectRELEASESFormat(text);
+    expect(text).toContain("app-2.8.0-beta.2-x64-full.nupkg");
+  });
+
+  it("500s when no release matches the version range", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    // ">=999.0.0" matches nothing -> "Version not found" -> plain Error -> 500
+    await supertest(app).get("/update/windows_64/999.0.0/RELEASES").expect(500);
+  });
+
+  it("500s when the release has no RELEASES asset", async () => {
+    const releases = ["2.7.0"].map((version) =>
+      buildRelease({
+        owner: OWNER,
+        repo: REPO,
+        version,
+        assets: buildFullPlatformAssets(OWNER, REPO, version).filter(
+          (a) => a.name !== "RELEASES"
+        ),
+      })
+    );
+    const { app } = configureTestAppWithReleases(releases);
+    const res = await supertest(app)
+      .get("/update/windows_64/2.5.0/RELEASES")
+      .expect(500);
+    expect(res.text).toContain("RELEASES File not found");
+  });
+
+  // The win32 alias maps to windows_32; the fixture (like most Electron apps
+  // today) only publishes x64, so 32-bit clients get a 500. Documented, not
+  // endorsed.
+  it("500s for win32 clients when only x64 assets exist", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    await supertest(app).get("/update/win32/2.5.0/RELEASES").expect(500);
+  });
+});

--- a/test/integration/update-win.spec.ts
+++ b/test/integration/update-win.spec.ts
@@ -77,8 +77,11 @@ describe("/update/:platform/:version/RELEASES (Squirrel.Windows)", () => {
         `${urlOf(res, "app-2.7.0-x64-full.nupkg")} ${SQUIRREL_NUPKG_SIZE}`
     );
 
-    // headers Squirrel.Windows relies on
-    expect(res.headers["content-length"]).toBe(String(text.length));
+    // headers Squirrel.Windows relies on; Content-Length is bytes, so
+    // compare against byteLength (equal to .length only for ASCII)
+    expect(res.headers["content-length"]).toBe(
+      String(Buffer.byteLength(text))
+    );
     expect(res.headers["content-disposition"]).toContain("RELEASES");
   });
 

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -1,0 +1,101 @@
+import { Webhooks } from "@octokit/webhooks";
+import nock from "nock";
+import supertest from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildStableReleaseSet, buildRelease, buildFullPlatformAssets } from "../fixtures/builders";
+import { configureTestAppWithReleases } from "../harness";
+import { nockGithubListReleases } from "../nock/nockGithubListReleases";
+
+nock.disableNetConnect();
+nock.enableNetConnect(/(localhost|127\.0\.0\.1)/);
+
+const OWNER = process.env.GITHUB_OWNER as string;
+const REPO = process.env.GITHUB_REPO as string;
+const SECRET = "webhook-test-secret";
+
+async function signedReleaseEvent(secret: string) {
+  const payload = JSON.stringify({
+    action: "published",
+    release: { id: 1, tag_name: "v2.8.0" },
+    repository: { full_name: `${OWNER}/${REPO}` },
+  });
+  const webhooks = new Webhooks({ secret });
+  const signature = await webhooks.sign(payload);
+  return { payload, signature };
+}
+
+describe("/webhook/refresh (GitHub release webhook)", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("busts the release cache on a signed release event", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+      { refreshSecret: SECRET }
+    );
+
+    // warm the cache with the initial release list
+    const before = await supertest(app).get("/api/versions").expect(200);
+    expect(before.body).toHaveLength(3);
+
+    // the refresh triggered by the webhook fetches this updated list
+    const updated = [
+      buildRelease({
+        owner: OWNER,
+        repo: REPO,
+        version: "2.8.0",
+        assets: buildFullPlatformAssets(OWNER, REPO, "2.8.0"),
+      }),
+      ...buildStableReleaseSet(OWNER, REPO),
+    ];
+    nockGithubListReleases(nock, OWNER, REPO, updated);
+
+    const { payload, signature } = await signedReleaseEvent(SECRET);
+    await supertest(app)
+      .post("/webhook/refresh")
+      .set("Content-Type", "application/json")
+      .set("X-GitHub-Event", "release")
+      .set("X-GitHub-Delivery", "test-delivery-1")
+      .set("X-Hub-Signature-256", signature)
+      .send(payload)
+      .expect(200);
+
+    // the handler fires refreshCache without awaiting it; poll until the
+    // refreshed list lands
+    await vi.waitFor(async () => {
+      const after = await supertest(app).get("/api/versions").expect(200);
+      expect(after.body).toHaveLength(4);
+      expect(after.body[0].version).toBe("2.8.0");
+    });
+  });
+
+  it("rejects a bad signature", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+      { refreshSecret: SECRET }
+    );
+    const { payload } = await signedReleaseEvent(SECRET);
+    const res = await supertest(app)
+      .post("/webhook/refresh")
+      .set("Content-Type", "application/json")
+      .set("X-GitHub-Event", "release")
+      .set("X-GitHub-Delivery", "test-delivery-2")
+      .set("X-Hub-Signature-256", "sha256=0000000000000000")
+      .send(payload);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it("is a no-op 404 when no refreshSecret is configured", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const { payload, signature } = await signedReleaseEvent(SECRET);
+    await supertest(app)
+      .post("/webhook/refresh")
+      .set("Content-Type", "application/json")
+      .set("X-GitHub-Event", "release")
+      .set("X-GitHub-Delivery", "test-delivery-3")
+      .set("X-Hub-Signature-256", signature)
+      .send(payload)
+      .expect(404);
+  });
+});

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -81,7 +81,9 @@ describe("/webhook/refresh (GitHub release webhook)", () => {
       .set("X-GitHub-Delivery", "test-delivery-2")
       .set("X-Hub-Signature-256", "sha256=0000000000000000")
       .send(payload);
+    // a 4xx rejection specifically - a crashing handler (5xx) must not pass
     expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
   });
 
   it("is a no-op 404 when no refreshSecret is configured", async () => {

--- a/test/nock/nockGithubAssetContent.ts
+++ b/test/nock/nockGithubAssetContent.ts
@@ -1,0 +1,26 @@
+import { PecansAsset } from "../../src/models";
+import { Nock } from "./Nock";
+
+/**
+ * Mock the GitHub asset endpoint to return the asset's content directly
+ * (200 + body) rather than a 302 redirect. Backend.readAsset() /
+ * getAssetStream() fetch `asset.raw.url` with `Accept: application/octet-stream`
+ * and consume the response body, so a direct 200 models the post-redirect
+ * response without needing a second interceptor.
+ */
+export function nockGithubAssetContent(
+  nock: Nock,
+  owner: string,
+  repo: string,
+  asset: PecansAsset,
+  content: string | Buffer
+) {
+  nock("https://api.github.com:443", { encodedQueryParams: true })
+    .get(`/repos/${owner}/${repo}/releases/assets/${asset.id}`)
+    .reply(200, content, [
+      "Content-Type",
+      "application/octet-stream",
+      "Content-Length",
+      String(Buffer.byteLength(content)),
+    ]);
+}

--- a/test/nock/nockGithubListReleases.ts
+++ b/test/nock/nockGithubListReleases.ts
@@ -10,13 +10,19 @@ export function get_mock_content_type(filename: string) {
   return "application/octet-stream";
 }
 
+export interface MockGithubAssetOpts {
+  size?: number;
+  content_type?: string;
+}
+
 export function mock_github_asset(
   owner: string,
   repo: string,
-  filename: string
+  filename: string,
+  opts: MockGithubAssetOpts = {}
 ): Partial<GithubReleaseAsset> {
   const id = parseInt(numericId(8));
-  const content_type = get_mock_content_type(filename);
+  const content_type = opts.content_type ?? get_mock_content_type(filename);
   return {
     url: `https://api.github.com/repos/${owner}/${repo}/releases/assets/${id}`,
     id,
@@ -25,7 +31,7 @@ export function mock_github_asset(
     label: "",
     content_type,
     state: "uploaded",
-    size: 143940252,
+    size: opts.size ?? 143940252,
     download_count: 0,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
@@ -39,11 +45,13 @@ export function mock_github_release(
   tag_name: string,
   assets: Partial<GithubReleaseAsset>[],
   draft = false,
-  prerelease = false
+  prerelease = false,
+  body: string | null = null,
+  published: string | null = null
 ): Partial<GithubRelease> {
   const id = parseInt(numericId(8));
-  const created_at = new Date().toISOString();
-  const published_at = draft ? null : new Date().toISOString();
+  const created_at = published ?? new Date().toISOString();
+  const published_at = draft ? null : published ?? new Date().toISOString();
   const url = `https://api.github.com/repos/${owner}/${repo}/releases/${id}`;
 
   return {
@@ -60,7 +68,7 @@ export function mock_github_release(
     assets: assets as GithubReleaseAsset[],
     tarball_url: null,
     zipball_url: null,
-    body: null,
+    body,
   };
 }
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,8 +2,9 @@
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "es2015"
+    "target": "es2015",
+    "rootDir": ".",
+    "noEmit": true
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary

Phase 1 of the modernization roadmap from the architecture review: **pin the full HTTP contract with e2e tests before any refactoring begins.** Before this PR, route-level coverage was two tests (`/dl/:filename` + release pagination); every other route was a TODO stub. This PR adds 79 integration tests so the Electron autoUpdater contracts and the rest of the route surface are frozen against regressions.

### Phase 0 findings (no code changes)
- Baseline on `next`: 632 tests / 24 files green, build green.
- **Module-format gate:** `spaceagetv/missioncontrol-api` couldn't be added to the session (approval blocked), so Phase 3 defaults to **dual CJS+ESM via tsup**; flipping to ESM-only is a one-line config change if the consumer supports it.
- electron-updater (electron-builder generic provider) support filed as backlog: #29.

### Harness refresh (Step A)
- `supertest` 6 → 7, `@types/supertest` → 6.
- `test/fixtures/builders.ts`: composable release/asset builders with deterministic `published_at` (channel-latest logic compares timestamps; wall-clock mocks were flaky), full platform matrices (dmg/zip/exe/nupkg/deb/rpm/tar.gz), and a **Squirrel.Windows fixture** (RELEASES + full/delta nupkgs) that didn't exist before.
- `test/harness.ts`: shared app/backend setup extracted from `integration.spec.ts`.
- `test/helpers/contracts.ts`: `expectSquirrelMacResponse` (exact `{url, name, notes, pub_date}` key set) and `expectRELEASESFormat` (LF, no BOM, `<sha1> <absolute /dl/ url> <size>` lines).
- `test/nock/nockGithubAssetContent.ts`: serves asset bodies so `readAsset()` flows (RELEASES proxying) work under nock.
- `tsconfig.test.json`: fixed `rootDir` so `src` + `test` typecheck (26 pre-existing TS6059 errors).

### Contract coverage (Step B)
- **Squirrel.Mac** (`/update/:platform/:version` + channel variant): 204 when current/ahead, 200 JSON with the exact key set, notes aggregation across versions, update URL resolving to a `.zip`, legacy `darwin` alias, prerelease isolation from stable clients.
- **Squirrel.Windows** (`.../RELEASES` + channel variant): byte-exact RELEASES output (sha/size passthrough, delta+full preserved, absolute `/dl/` URLs), `Content-Length`/`Content-Disposition`, nupkg 302 download, legacy `win-x64` alias.
- **Downloads**: `/`, `/download/:platform?` (canonical ids, legacy aliases, UA sniffing, `?tag`, `?filetype`, `preferUniversal`), `/download/channel/...`, `/download/:tag/:filename`, `/download/version/:tag/:platform?`, `/dl/:filename`, `/dl/:os/:arch` (per-OS/arch matrix, `?version`/`?channel`/`?pkg`, 404 shapes).
- **API**: `/api/channels`, `/api/versions` (all filters), `/notes` (json + text).
- **Webhook**: signed `release` event busts the cache; bad signature rejected; no-secret no-op.

### Bugs discovered and pinned as `it.fails()` (intended behavior; fixes land in Phase 2)
1. `handleDownload` ignores `req.params.channel` — the `/download/channel/:channel` segment has no effect.
2. `handleDownload` ignores `req.params.tag` — `/download/:tag/:filename` and `/download/version/:tag` always resolve the newest release.
3. Without a tag, the channel is widened to `*`, so **stable users are served prereleases** when one is the highest semver.
4. `/download/version/:tag` (no platform) is shadowed by `/download/:tag/:filename` and 500s.
5. `PecansAsset.satisfiesExtensions` uses `path.extname`, so `.tar.gz` assets can never match (`/dl/linux/64` 404s on a tar.gz-only fixture).
6. `/api/status` handler exists but was never routed.

### Verification
- `npm test`: 30 files / **711 passed** (632 baseline + 79 new).
- `npx tsc -p tsconfig.test.json`: clean.
- `npm run build`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zUyj4PpSog9RkrYxzFRhM

---
_Generated by [Claude Code](https://claude.ai/code/session_015zUyj4PpSog9RkrYxzFRhM)_