### PR TITLE
fix: honor route params in downloads, dead code removal, small fixes (Phase 2)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "plugins": ["@babel/plugin-transform-modules-commonjs"]
-}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Pecans is an Electron Release Server.
 - Download URLs
   - `/` — detect platform from the browser user agent and serve the latest build
   - `/download/:platform` — latest build for a platform (`osx_64`, `windows_64`, … legacy aliases like `darwin`, `win32`, `mac-arm64` are accepted)
-  - `/download/channel/:channel/:platform` — latest build on a release channel
-  - `/download/version/:tag/:platform` — a specific version
+  - `/download/channel/:channel/:platform?` — latest build on a release channel (platform falls back to user-agent detection when omitted)
+  - `/download/version/:tag/:platform?` — a specific version (platform falls back to user-agent detection when omitted)
   - `/download/:tag/:filename` — a specific release asset by filename
   - `/dl/:os/:arch` — resolve by discrete OS (`osx`, `windows`, `linux`) and arch (`32`, `64`, `arm64`, `universal`); supports `?channel`, `?version`, and `?pkg` (`deb`/`rpm`) queries
   - `/dl/:filename` — a release asset by filename

--- a/README.md
+++ b/README.md
@@ -4,27 +4,32 @@ Pecans is an Electron Release Server.
 
 ## Features
 
-- Download URLS
-  - `/download/latest`
-  - `/download/latest/:os`
-  - `/download/:version`
-  - `/download/:version/:os`
-  - `/download/channel/:channel`
-  - `/download/channel/:channel/:os`
+- Download URLs
+  - `/` — detect platform from the browser user agent and serve the latest build
+  - `/download/:platform` — latest build for a platform (`osx_64`, `windows_64`, … legacy aliases like `darwin`, `win32`, `mac-arm64` are accepted)
+  - `/download/channel/:channel/:platform` — latest build on a release channel
+  - `/download/version/:tag/:platform` — a specific version
+  - `/download/:tag/:filename` — a specific release asset by filename
+  - `/dl/:os/:arch` — resolve by discrete OS (`osx`, `windows`, `linux`) and arch (`32`, `64`, `arm64`, `universal`); supports `?channel`, `?version`, and `?pkg` (`deb`/`rpm`) queries
+  - `/dl/:filename` — a release asset by filename
 - Auto-updates with [Squirrel](https://github.com/Squirrel)
-  - For Mac using Squirrel.Mac `/update?version=<x.x.x>&platform=osx`
+  - For Mac using Squirrel.Mac
     - `/update/:platform/:version`
-      `/update/channel/:channel/:platform/:version`
-  - For Windows using Squirrel.Windows and Nugets packages
+    - `/update/channel/:channel/:platform/:version`
+    - `/update?version=<x.x.x>&platform=osx` (deprecated; redirects to `/update/:platform/:version`)
+  - For Windows using Squirrel.Windows and NuGet packages
     - `/update/:platform/:version/RELEASES`
     - `/update/channel/:channel/:platform/:version/RELEASES`
+- API
+  - `/api/channels` — release channels with their latest versions
+  - `/api/versions` — releases, filterable with `?channel`, `?platform`, `?version`
+  - `/api/status` — server uptime
+- Release Notes API, `/notes?version=<x.x.x>` (JSON or plain text via `Accept`)
 - GitHub Release Integration
 - GitHub Private Repository Hosted Releases
-- GitHub Release Webhook to keep releases up-to-date.
+- GitHub Release Webhook to keep releases up-to-date
 - Release Channels (`beta`, `alpha`, ...)
 - Express App (composable)
-- Release Noted API, `/notes/:version`
-- Atom/RSS feeds for versions/channels
 
 ## Deploy it / Start it
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,10 @@
       "dependencies": {
         "@octokit/rest": "^20.0.1",
         "@octokit/webhooks": "^12.0.3",
-        "body-parser": "^1.19.0",
         "express": "^4.18.1",
         "express-useragent": "^1.0.15",
         "semver": "^7.3.7",
-        "ts-node": "^10.8.1",
-        "urljoin.js": "^1.0.0",
-        "uuid": "^8.3.2"
+        "ts-node": "^10.8.1"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.1",
@@ -10128,11 +10125,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pathname": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
-    },
     "node_modules/responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
@@ -11733,14 +11725,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/urljoin.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urljoin.js/-/urljoin.js-1.0.0.tgz",
-      "integrity": "sha512-F8+V9v5NctUgVbAKvw508qBqpWrb0xuFMCX9UpdrfuLAFbxO21YVuFdXZA94AQz2s3v+3a6uruHuC7touIa9SA==",
-      "dependencies": {
-        "resolve-pathname": "2.2.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11753,14 +11737,6 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -19227,11 +19203,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
-    "resolve-pathname": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
-    },
     "responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
@@ -20355,14 +20326,6 @@
         "prepend-http": "^2.0.0"
       }
     },
-    "urljoin.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urljoin.js/-/urljoin.js-1.0.0.tgz",
-      "integrity": "sha512-F8+V9v5NctUgVbAKvw508qBqpWrb0xuFMCX9UpdrfuLAFbxO21YVuFdXZA94AQz2s3v+3a6uruHuC7touIa9SA==",
-      "requires": {
-        "resolve-pathname": "2.2.0"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -20373,11 +20336,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,10 @@
   "dependencies": {
     "@octokit/rest": "^20.0.1",
     "@octokit/webhooks": "^12.0.3",
-    "body-parser": "^1.19.0",
     "express": "^4.18.1",
     "express-useragent": "^1.0.15",
     "semver": "^7.3.7",
-    "ts-node": "^10.8.1",
-    "urljoin.js": "^1.0.0",
-    "uuid": "^8.3.2"
+    "ts-node": "^10.8.1"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",

--- a/src/models/PecansAsset.ts
+++ b/src/models/PecansAsset.ts
@@ -1,4 +1,3 @@
-import { extname } from "path";
 import {
   Architecture,
   filenameToArchitecture,
@@ -8,7 +7,10 @@ import {
   PackageFormat,
   Platform,
 } from "../utils";
-import { SupportedFileExtension } from "../utils/SupportedFileExtension";
+import {
+  getSupportedExt,
+  SupportedFileExtension,
+} from "../utils/SupportedFileExtension";
 import { PecansAssetQuery } from "./PecansAssetQuery";
 
 export interface PecansAssetDTO {
@@ -72,7 +74,9 @@ export class PecansAsset implements PecansAssetDTO {
 
   satisfiesExtensions(extensions?: SupportedFileExtension[]) {
     if (!extensions) return true;
-    const ext = extname(this.filename);
-    return extensions.includes(ext as SupportedFileExtension);
+    // getSupportedExt handles the ".tar.gz" double extension, which
+    // path.extname would report as ".gz"
+    const ext = getSupportedExt(this.filename);
+    return ext != undefined && extensions.includes(ext);
   }
 }

--- a/src/models/PecansRelease.ts
+++ b/src/models/PecansRelease.ts
@@ -39,7 +39,7 @@ export class PecansRelease implements PecansReleaseDTO {
         }
       })
       .filter<PecansAsset>(isPecansAsset);
-    this.channel = channelFromVersion(dto.version);
+    this.channel = dto.channel || channelFromVersion(dto.version);
     this.notes = dto.notes;
     this.published_at = dto.published_at;
     this.version = dto.version;

--- a/src/models/PecansRelease.ts
+++ b/src/models/PecansRelease.ts
@@ -7,6 +7,11 @@ import { PecansReleaseQuery } from "./PecansReleaseQuery";
 export interface PecansReleaseDTO {
   // version
   assets: PecansAssetDTO[];
+  /**
+   * @deprecated ignored - the channel is always derived from the version's
+   * prerelease identifier (channelFromVersion), so channel and version can
+   * never disagree. Will be removed in 3.0.
+   */
   channel: string;
   notes: string;
   // missing published_at indicates a draft that hasn't been published.
@@ -26,6 +31,9 @@ export class PecansRelease implements PecansReleaseDTO {
   version: string;
 
   constructor(dto: PecansReleaseDTO) {
+    // the version string is the single source of truth for the channel;
+    // dto.channel is deliberately ignored (see PecansReleaseDTO.channel)
+    this.channel = channelFromVersion(dto.version);
     this.assets = dto.assets
       .map((assetDTO) => {
         try {
@@ -33,13 +41,12 @@ export class PecansRelease implements PecansReleaseDTO {
           return asset;
         } catch (err) {
           console.error(
-            `Error parsing asset: ${assetDTO.filename} for release ${dto.version}/${dto.channel}`,
+            `Error parsing asset: ${assetDTO.filename} for release ${dto.version}/${this.channel}`,
             err
           );
         }
       })
       .filter<PecansAsset>(isPecansAsset);
-    this.channel = dto.channel || channelFromVersion(dto.version);
     this.notes = dto.notes;
     this.published_at = dto.published_at;
     this.version = dto.version;

--- a/src/pecans.ts
+++ b/src/pecans.ts
@@ -41,7 +41,7 @@ import { VersionFilterOpts, Versions } from "./versions";
 const logger = Debug("pecans");
 
 export interface PecansSettings {
-  /** Timeout for releases cache (seconds) */
+  /** @deprecated accepted but never read; will be removed in 3.0 */
   timeout: number;
   /** Base path for all routes */
   basePath: string;
@@ -223,12 +223,14 @@ export class Pecans extends EventEmitter {
       "/download/channel/:channel/:platform?",
       this.handleDownload.bind(this)
     );
-    this.router.get("/download/:platform?", this.handleDownload.bind(this));
-    this.router.get("/download/:tag/:filename", this.handleDownload.bind(this));
+    // /download/version must register before /download/:tag/:filename or the
+    // literal "version" segment is captured as :tag and the request 500s.
     this.router.get(
       "/download/version/:tag/:platform?",
       this.handleDownload.bind(this)
     );
+    this.router.get("/download/:platform?", this.handleDownload.bind(this));
+    this.router.get("/download/:tag/:filename", this.handleDownload.bind(this));
 
     // the /dl path will supersede the /download/**  paths
     this.router.get("/dl/:filename", this.dlfilename.bind(this));
@@ -237,6 +239,7 @@ export class Pecans extends EventEmitter {
     // #endregion
 
     this.router.get("/api/channels", this.handleApiChannels.bind(this));
+    this.router.get("/api/status", this.handleApiStatus.bind(this));
     // ?channel?platform?version
     this.router.get("/api/versions", this.handleApiVersions.bind(this));
 
@@ -437,8 +440,10 @@ export class Pecans extends EventEmitter {
     next: NextFunction
   ) {
     try {
-      let channel = validateReqQueryChannel(req.query.channel || "stable");
-      const tag = validateReqQueryTag(req.query.tag);
+      let channel = validateReqQueryChannel(
+        req.params.channel || req.query.channel || "stable"
+      );
+      const tag = validateReqQueryTag(req.params.tag ?? req.query.tag);
       const filename = req.params.filename;
       const filetype = getFiletypeFromQuery(req.query);
 
@@ -451,8 +456,9 @@ export class Pecans extends EventEmitter {
       }
       const platform = validateReqQueryPlatform(mapped_platform);
 
-      // If specific version, don't enforce a channel
-      if (tag != "latest") channel = "*";
+      // If a specific version was requested, don't enforce a channel; an
+      // absent tag means "latest" and keeps the requested/default channel.
+      if (tag && tag != "latest") channel = "*";
 
       let release: PecansRelease | undefined = undefined;
       try {
@@ -465,7 +471,7 @@ export class Pecans extends EventEmitter {
       } catch (err) {
         // if we didn't restrict by channel or we specified a specific tag
         // don't try to fallback to any channel
-        if (channel == "*" || tag != "latest") throw err;
+        if (channel == "*" || (tag && tag != "latest")) throw err;
       }
 
       // we weren't able to find a release with the specified channel
@@ -614,7 +620,8 @@ export class Pecans extends EventEmitter {
 
       const output = generateRELEASES(releases);
 
-      res.header("Content-Length", output.length.toString());
+      // Content-Length is bytes, not UTF-16 code units
+      res.header("Content-Length", Buffer.byteLength(output).toString());
       res.attachment("RELEASES");
       res.send(output);
     } catch (err) {

--- a/src/pecans.ts
+++ b/src/pecans.ts
@@ -41,7 +41,7 @@ import { VersionFilterOpts, Versions } from "./versions";
 const logger = Debug("pecans");
 
 export interface PecansSettings {
-  /** @deprecated accepted but never read; will be removed in 3.0 */
+  /** @deprecated accepted but unused (defaulted, no functional effect); will be removed in 3.0 */
   timeout: number;
   /** Base path for all routes */
   basePath: string;
@@ -469,9 +469,10 @@ export class Pecans extends EventEmitter {
           preferUniversal: this.opts.preferUniversal,
         });
       } catch (err) {
-        // if we didn't restrict by channel or we specified a specific tag
-        // don't try to fallback to any channel
-        if (channel == "*" || (tag && tag != "latest")) throw err;
+        // don't fall back to any channel if we already searched them all;
+        // a specific tag widened channel to "*" above, so this covers both
+        // "unrestricted" and "specific version requested"
+        if (channel == "*") throw err;
       }
 
       // we weren't able to find a release with the specified channel

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -4,7 +4,6 @@ import { PecansRelease } from "./models/PecansRelease";
 import { sortReleaseBySemVerDescending } from "./utils/sortReleaseBySemVerDescending";
 import { isPlatform, Platform } from "./utils";
 import { UnsupportedPlatformError } from "./pecans";
-import { reset } from "express-useragent";
 
 export type PlatformQuery = Platform | undefined;
 

--- a/test/integration/api.spec.ts
+++ b/test/integration/api.spec.ts
@@ -120,8 +120,7 @@ describe("/api/versions", () => {
 describe("/api/status", () => {
   afterEach(() => nock.cleanAll());
 
-  // handleApiStatus exists but is not routed; Phase 2 wires it to /api/status
-  it.fails("reports uptime (intended - wired in Phase 2)", async () => {
+  it("reports uptime", async () => {
     const { app } = configureTestAppWithReleases(
       buildStableReleaseSet(OWNER, REPO)
     );

--- a/test/integration/dl.spec.ts
+++ b/test/integration/dl.spec.ts
@@ -26,6 +26,7 @@ describe("/dl/:os/:arch", () => {
     ["/dl/osx/arm64", "app-2.7.0-arm64.dmg"],
     ["/dl/osx/universal", "app-2.7.0-univ.dmg"],
     ["/dl/windows/64", "app-2.7.0-x64-setup.exe"],
+    ["/dl/linux/64", "app-2.7.0-linux-x64.tar.gz"],
     ["/dl/linux/64?pkg=deb", "app-2.7.0-linux-x64.deb"],
     ["/dl/linux/64?pkg=rpm", "app-2.7.0-linux-x64.rpm"],
   ];
@@ -38,32 +39,6 @@ describe("/dl/:os/:arch", () => {
     nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
     const res = await supertest(app).get(url).expect(302);
     expect(res.headers.location).toContain(filename);
-  });
-
-  // BUG (fix in Phase 2): PecansAsset.satisfiesExtensions uses path.extname,
-  // which yields ".gz" for ".tar.gz" filenames, so a plain /dl/linux/64
-  // request can never match a .tar.gz asset. getSupportedExt() already handles
-  // the double extension and should be used instead.
-  it.fails("/dl/linux/64 redirects to the tar.gz asset (intended)", async () => {
-    const { app, backend } = configureTestAppWithReleases(
-      buildStableReleaseSet(OWNER, REPO)
-    );
-    const asset = await findAsset(
-      backend,
-      "2.7.0",
-      "app-2.7.0-linux-x64.tar.gz"
-    );
-    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
-    const res = await supertest(app).get("/dl/linux/64").expect(302);
-    expect(res.headers.location).toContain("app-2.7.0-linux-x64.tar.gz");
-  });
-
-  it("/dl/linux/64 currently 404s on a .tar.gz-only fixture (see bug above)", async () => {
-    const { app } = configureTestAppWithReleases(
-      buildStableReleaseSet(OWNER, REPO)
-    );
-    const res = await supertest(app).get("/dl/linux/64").expect(404);
-    expect(res.text).toContain("No Matching Assets Found");
   });
 
   it("?version selects an older release", async () => {

--- a/test/integration/download.spec.ts
+++ b/test/integration/download.spec.ts
@@ -2,7 +2,9 @@ import nock from "nock";
 import supertest from "supertest";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  buildFullPlatformAssets,
   buildMixedChannelReleaseSet,
+  buildRelease,
   buildStableReleaseSet,
 } from "../fixtures/builders";
 import {
@@ -157,29 +159,36 @@ describe("/download/:platform?", () => {
     );
   });
 
-  // BUG (fix in Phase 2): when no tag is given, handleDownload widens the
-  // channel to "*" (the `tag != "latest"` check is true for undefined), so
-  // the newest release of ANY channel wins and stable users receive
-  // prereleases.
-  it.fails(
-    "/download/osx without a tag serves the latest STABLE release (intended)",
-    async () => {
-      const { app, backend } = configureTestAppWithReleases(
-        buildMixedChannelReleaseSet(OWNER, REPO)
-      );
-      const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
-      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
-      // also mock the asset today's buggy resolution serves, so the request
-      // completes and the assertion fails fast instead of timing out
-      const actual = await findAsset(
-        backend,
-        "2.8.0-beta.2",
-        "app-2.8.0-beta.2-univ.dmg"
-      );
-      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, actual);
-      await expectRedirectTo(app, "/download/osx", "app-2.7.0-univ.dmg");
-    }
-  );
+  // regression: an absent tag must not widen the channel to "*" - stable
+  // users must never be served prereleases (bug fixed in Phase 2)
+  it("/download/osx without a tag serves the latest STABLE release", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(app, "/download/osx", "app-2.7.0-univ.dmg");
+  });
+
+  it("falls back to any channel when no stable release exists", async () => {
+    const beta = ["2.8.0-beta.2", "2.8.0-beta.1"].map((version) =>
+      buildRelease({
+        owner: OWNER,
+        repo: REPO,
+        version,
+        prerelease: true,
+        assets: buildFullPlatformAssets(OWNER, REPO, version),
+      })
+    );
+    const { app, backend } = configureTestAppWithReleases(beta);
+    const asset = await findAsset(
+      backend,
+      "2.8.0-beta.2",
+      "app-2.8.0-beta.2-univ.dmg"
+    );
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(app, "/download/osx", "app-2.8.0-beta.2-univ.dmg");
+  });
 
   // README advertises /download/latest but "latest" parses as a platform and
   // 500s. Phase 2 aligns the README with the real route surface.
@@ -212,35 +221,22 @@ describe("/download/:platform?", () => {
 describe("/download/channel/:channel/:platform?", () => {
   afterEach(() => nock.cleanAll());
 
-  // BUG (fix in Phase 2): handleDownload reads the channel from the query
-  // string only; req.params.channel from this route is ignored, so the
-  // channel segment has no effect.
-  it.fails(
-    "/download/channel/stable/osx serves the latest stable release (intended)",
-    async () => {
-      const { app, backend } = configureTestAppWithReleases(
-        buildMixedChannelReleaseSet(OWNER, REPO)
-      );
-      const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
-      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
-      // see note above: mock the wrongly-served beta asset to fail fast
-      const actual = await findAsset(
-        backend,
-        "2.8.0-beta.2",
-        "app-2.8.0-beta.2-univ.dmg"
-      );
-      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, actual);
-      await expectRedirectTo(
-        app,
-        "/download/channel/stable/osx",
-        "app-2.7.0-univ.dmg"
-      );
-    }
-  );
+  // regression: the :channel path segment must be honored (bug fixed in
+  // Phase 2 - it was previously read from the query string only)
+  it("/download/channel/stable/osx serves the latest stable release", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/download/channel/stable/osx",
+      "app-2.7.0-univ.dmg"
+    );
+  });
 
   it("serves the latest beta via the beta channel route", async () => {
-    // passes today only because channel "*" resolves to the beta, which is
-    // the highest semver overall - not because the path channel is honored.
     const { app, backend } = configureTestAppWithReleases(
       buildMixedChannelReleaseSet(OWNER, REPO)
     );
@@ -274,24 +270,19 @@ describe("/download/:tag/:filename", () => {
     );
   });
 
-  // BUG (fix in Phase 2): handleDownload never reads req.params.tag - the tag
-  // comes from the query string only - so files from anything but the newest
-  // release cannot be downloaded through this route.
-  it.fails(
-    "serves a file from an older release by its tag segment (intended)",
-    async () => {
-      const { app, backend } = configureTestAppWithReleases(
-        buildStableReleaseSet(OWNER, REPO)
-      );
-      const asset = await findAsset(backend, "2.6.0", "app-2.6.0-x64.dmg");
-      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
-      await expectRedirectTo(
-        app,
-        "/download/2.6.0/app-2.6.0-x64.dmg",
-        "app-2.6.0-x64.dmg"
-      );
-    }
-  );
+  // regression: the :tag path segment must be honored (bug fixed in Phase 2)
+  it("serves a file from an older release by its tag segment", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO)
+    );
+    const asset = await findAsset(backend, "2.6.0", "app-2.6.0-x64.dmg");
+    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+    await expectRedirectTo(
+      app,
+      "/download/2.6.0/app-2.6.0-x64.dmg",
+      "app-2.6.0-x64.dmg"
+    );
+  });
 });
 
 describe("/download/version/:tag/:platform?", () => {
@@ -310,17 +301,13 @@ describe("/download/version/:tag/:platform?", () => {
     );
   });
 
-  // BUG (fix in Phase 2): req.params.tag is ignored, so this route always
-  // resolves the newest release regardless of the version segment.
-  it.fails("serves the version named in the path (intended)", async () => {
+  // regression: the :tag path segment must be honored (bug fixed in Phase 2)
+  it("serves the version named in the path", async () => {
     const { app, backend } = configureTestAppWithReleases(
       buildStableReleaseSet(OWNER, REPO)
     );
     const asset = await findAsset(backend, "2.6.0", "app-2.6.0-univ.dmg");
     nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
-    // see note above: mock the wrongly-served latest asset to fail fast
-    const actual = await findAsset(backend, "2.7.0", "app-2.7.0-univ.dmg");
-    nockGithubReleasesAssetRedirect(nock, OWNER, REPO, actual);
     await expectRedirectTo(
       app,
       "/download/version/2.6.0/osx",
@@ -328,11 +315,10 @@ describe("/download/version/:tag/:platform?", () => {
     );
   });
 
-  // BUG (fix in Phase 2): without the platform segment this path is shadowed
-  // by /download/:tag/:filename ("version" parses as the tag), which 500s.
-  // Intended: fall back to user-agent platform detection.
-  it.fails(
-    "falls back to user-agent detection without a platform segment (intended)",
+  // regression: this route registers before /download/:tag/:filename so the
+  // literal "version" segment is not captured as a tag (bug fixed in Phase 2)
+  it(
+    "falls back to user-agent detection without a platform segment",
     async () => {
       const { app, backend } = configureTestAppWithReleases(
         buildStableReleaseSet(OWNER, REPO)

--- a/test/unit/PecansRelease.spec.ts
+++ b/test/unit/PecansRelease.spec.ts
@@ -58,21 +58,13 @@ describe("PecansRelease", () => {
       expect(release.channel).toBe("beta");
     });
 
-    it("should honor an explicit channel from the DTO", () => {
-      const release = new PecansRelease(
-        createMockReleaseDTO({
-          version: "1.0.0",
-          channel: "nightly",
-        })
-      );
-      expect(release.channel).toBe("nightly");
-    });
-
-    it("should fall back to the version-derived channel when the DTO channel is empty", () => {
+    it("should ignore dto.channel - the version string is the source of truth", () => {
+      // PecansReleaseDTO.channel is deprecated and deliberately ignored so
+      // channel and version can never disagree
       const release = new PecansRelease(
         createMockReleaseDTO({
           version: "1.0.0-beta.1",
-          channel: "",
+          channel: "nightly",
         })
       );
       expect(release.channel).toBe("beta");

--- a/test/unit/PecansRelease.spec.ts
+++ b/test/unit/PecansRelease.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "../../src/models/PecansRelease.js";
 import { PecansAsset, PecansAssetDTO } from "../../src/models/PecansAsset.js";
 import { PecansReleaseQuery } from "../../src/models/PecansReleaseQuery.js";
+import { channelFromVersion } from "../../src/utils/channelFromVersion.js";
 
 describe("PecansRelease", () => {
   const createMockAssetDTO = (
@@ -22,14 +23,19 @@ describe("PecansRelease", () => {
 
   const createMockReleaseDTO = (
     overrides: Partial<PecansReleaseDTO> = {}
-  ): PecansReleaseDTO => ({
-    assets: [createMockAssetDTO()],
-    channel: "stable",
-    notes: "Release notes",
-    published_at: new Date("2023-01-01"),
-    version: "1.0.0",
-    ...overrides,
-  });
+  ): PecansReleaseDTO => {
+    const version = overrides.version ?? "1.0.0";
+    return {
+      assets: [createMockAssetDTO()],
+      // keep the fixture internally consistent: an explicit channel override
+      // wins, otherwise derive it from the effective version
+      channel: channelFromVersion(version),
+      notes: "Release notes",
+      published_at: new Date("2023-01-01"),
+      version,
+      ...overrides,
+    };
+  };
 
   describe("constructor", () => {
     it("should create instance with all properties from DTO", () => {
@@ -47,6 +53,26 @@ describe("PecansRelease", () => {
       const release = new PecansRelease(
         createMockReleaseDTO({
           version: "1.0.0-beta.1",
+        })
+      );
+      expect(release.channel).toBe("beta");
+    });
+
+    it("should honor an explicit channel from the DTO", () => {
+      const release = new PecansRelease(
+        createMockReleaseDTO({
+          version: "1.0.0",
+          channel: "nightly",
+        })
+      );
+      expect(release.channel).toBe("nightly");
+    });
+
+    it("should fall back to the version-derived channel when the DTO channel is empty", () => {
+      const release = new PecansRelease(
+        createMockReleaseDTO({
+          version: "1.0.0-beta.1",
+          channel: "",
         })
       );
       expect(release.channel).toBe("beta");

--- a/test/unit/PecansReleases.spec.ts
+++ b/test/unit/PecansReleases.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "../../src/models/PecansRelease.js";
 import { PecansAssetDTO } from "../../src/models/PecansAsset.js";
 import { PecansReleaseQuery } from "../../src/models/PecansReleaseQuery.js";
+import { channelFromVersion } from "../../src/utils/channelFromVersion.js";
 
 describe("PecansReleases", () => {
   const createMockAssetDTO = (filename: string): PecansAssetDTO => ({
@@ -23,7 +24,9 @@ describe("PecansReleases", () => {
     overrides: Partial<PecansReleaseDTO> = {}
   ): PecansReleaseDTO => ({
     assets: [createMockAssetDTO(`${version}-app.dmg`)],
-    channel: "stable",
+    // keep the fixture internally consistent: an explicit channel override
+    // wins, otherwise derive it from the version
+    channel: channelFromVersion(version),
     notes: `Release notes for ${version}`,
     published_at: publishedAt,
     version,

--- a/test/unit/PecansReleases.spec.ts
+++ b/test/unit/PecansReleases.spec.ts
@@ -22,16 +22,19 @@ describe("PecansReleases", () => {
     version: string,
     publishedAt: Date,
     overrides: Partial<PecansReleaseDTO> = {}
-  ): PecansReleaseDTO => ({
-    assets: [createMockAssetDTO(`${version}-app.dmg`)],
-    // keep the fixture internally consistent: an explicit channel override
-    // wins, otherwise derive it from the version
-    channel: channelFromVersion(version),
-    notes: `Release notes for ${version}`,
-    published_at: publishedAt,
-    version,
-    ...overrides,
-  });
+  ): PecansReleaseDTO => {
+    // derive dependent fields from the version an override may replace, so
+    // the fixture stays internally consistent
+    const effectiveVersion = overrides.version ?? version;
+    return {
+      assets: [createMockAssetDTO(`${effectiveVersion}-app.dmg`)],
+      channel: channelFromVersion(effectiveVersion),
+      notes: `Release notes for ${effectiveVersion}`,
+      published_at: publishedAt,
+      version: effectiveVersion,
+      ...overrides,
+    };
+  };
 
   describe("constructor", () => {
     it("should create instance with sorted releases", () => {


### PR DESCRIPTION
## Summary

Phase 2 of the modernization roadmap: fix the bugs pinned by the Phase 1 contract suite (#30) and clear out dead code. Every `it.fails()` pin from Phase 1 is flipped to a green regression test; the Squirrel.Mac / Squirrel.Windows contract tests are unchanged and still pass, so update clients are unaffected.

### Behavior fixes (were `it.fails()` pins in #30)
- **`handleDownload` honors `req.params.channel` and `req.params.tag`.** Previously both came from the query string only, so `/download/channel/stable/osx` ignored its channel segment and `/download/version/2.6.0/osx` silently served the newest release.
- **Stable users no longer receive prereleases.** An absent tag no longer widens the channel to `*`; the newest release *of the requested channel* wins. If the requested channel has no releases (e.g. a prerelease-only repo), resolution still falls back to any channel — new test covers this.
- **Route-shadowing fixed**: `/download/version/:tag/:platform?` registers before `/download/:tag/:filename`, so `/download/version/2.7.0` (no platform) now falls back to user-agent detection instead of 500ing.
- **`.tar.gz` assets resolve**: `PecansAsset.satisfiesExtensions` now uses `getSupportedExt` (which handles the double extension) instead of `path.extname` (which reported `.gz`); `/dl/linux/64` serves the tarball instead of 404ing.
- **RELEASES `Content-Length` computed with `Buffer.byteLength`** (bytes, not UTF-16 code units) — the source-side counterpart of a Copilot review finding on #30. Latent only, since RELEASES content is ASCII today.
- **`GET /api/status` wired** — the handler existed but was never routed.

### Design decision: channel is strictly derived from the version string
`PecansReleaseDTO.channel` has been ignored by the `PecansRelease` constructor since the class was introduced; an earlier commit on this branch made the field effective (dto wins, derived fallback). After design review this was **deliberately reversed**: the version string's prerelease identifier is the single source of truth for a release's channel (`channelFromVersion`), so channel and version can never disagree and a mislabeling backend bug is structurally impossible. `PecansReleaseDTO.channel` is now documented `@deprecated` (ignored; removal in 3.0). Backends express channels via version prerelease ids (e.g. `2.4.0-nightly.12`), which is what the Squirrel.Windows version mapping assumes anyway. A unit test pins the ignore contract.

### Cleanup
- Removed unused runtime dependencies: `uuid`, `urljoin.js`, `body-parser` (zero imports).
- Removed `.babelrc` (no babel packages installed) and an unused `express-useragent` import in `versions.ts`.
- Deprecated `PecansOptions.timeout` (accepted but never read; removal in 3.0).
- README now documents the real route surface (`/notes?version=`, `/dl/:os/:arch`, deprecated `/update?query`) and drops the unimplemented Atom/RSS feeds claim.

### Verification
- `npm test`: 30 files / **712 passed**.
- `npx tsc -p tsconfig.test.json`: clean.
- `npm run build`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zUyj4PpSog9RkrYxzFRhM