### PR TITLE
fix: working generic refresh webhook; document raw as the backend-private asset slot (Phase 7 PR A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ Pecans is an Electron Release Server.
 
 This server provides an endpoint for [Squirrel auto-updater](https://github.com/atom/electron/blob/master/docs/api/auto-updater.md), it supports both [OS X](https://pecans.darrelopry.com/v/main/docs/update-osx) and [Windows](https://pecans.darrelopry.com/v/main/docs/update-windows).
 
+## Cache-refresh webhook
+
+Release lists are cached (2 hours by default). `POST /webhook/refresh` busts
+the cache without waiting for expiry; it is enabled by configuring a
+`refreshSecret` on the backend and disabled otherwise.
+
+- **GitHub backend**: point a GitHub _release_ webhook at
+  `/webhook/refresh` with the secret set to your `refreshSecret`; the
+  payload signature is verified with
+  [@octokit/webhooks](https://github.com/octokit/webhooks.js).
+- **Other backends** (base `Backend` middleware): send the `refreshSecret`
+  in an `X-Pecans-Secret` header or a `?secret=` query parameter. A valid
+  request responds `200 {"refreshed": true}`; a missing or wrong secret
+  responds `403`.
+
 ## Documentation
 
 [Check out the documentation](https://pecans.darrelopry.com/v/main/docs) for more details.

--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -1,8 +1,9 @@
 import { Buffer } from "buffer";
-import { createHash } from "crypto";
+import { createHash, timingSafeEqual } from "crypto";
 import { NextFunction, Request, Response } from "express";
 import { pipeline, Writable } from "stream";
 import { promisify } from "util";
+import { ForbiddenError } from "../errors";
 import { PecansReleases } from "../models";
 import { PecansAsset, PecansAssetDTO } from "../models/PecansAsset";
 
@@ -74,14 +75,21 @@ export abstract class Backend {
     return this.cache;
   }
 
-  // return an express middlware to catch a specific path
-  // ex) `app.use(backend.getRefreshMiddleware('/api/backend/refresh'))`
+  // Return an express middleware guarding a cache-refresh endpoint, for
+  // backends without their own webhook verification (the GitHub backend
+  // overrides this with signed-payload verification via @octokit/webhooks).
+  //
+  // The caller authenticates by sending the configured refreshSecret in an
+  // `X-Pecans-Secret` header or `?secret=` query parameter; a request on the
+  // watched path with a missing or wrong secret gets a 403. When no
+  // refreshSecret is configured the middleware is a pass-through and the
+  // endpoint stays disabled — the secret requirement prevents DOS attacks
+  // against update infrastructure.
+  // ex) `app.use(backend.getRefreshWebhookMiddleware('/api/backend/refresh'))`
   getRefreshWebhookMiddleware(
-    // path that the firmware will watch.
+    // path that the middleware will watch.
     path: string,
-  ): (req: Request, res: Response, nex: NextFunction) => void {
-    // the default refresh callback expects a base64 encoded sha256 hash of the refreshSecret.
-    // the secret is to prevent DOS attacks against update infrastructure.
+  ): (req: Request, res: Response, next: NextFunction) => void {
     const middleware = (req: Request, res: Response, next: NextFunction) => {
       // only do stuff if a secret was provided, otherwise just call next.
       if (!this.hash) {
@@ -92,19 +100,36 @@ export abstract class Backend {
         next();
         return;
       }
-      if (this.hash != req.params.secret) {
-        next("bad secret");
+      // the middleware is mounted with use(), so req.params is never
+      // populated here - the secret arrives as a header or query parameter
+      const query = req.query.secret;
+      const provided =
+        req.get("x-pecans-secret") ??
+        (typeof query === "string" ? query : undefined);
+      if (!provided || !this.verifyRefreshSecret(provided)) {
+        next(new ForbiddenError("Invalid refresh secret"));
         return;
       }
       this.refreshCache()
         .then(() => {
-          next();
+          res.status(200).json({ refreshed: true });
         })
         .catch((err) => {
           next(err);
         });
     };
     return middleware;
+  }
+
+  // constant-time comparison of the provided secret's sha256 against the
+  // stored hash, so the comparison doesn't leak match progress via timing
+  private verifyRefreshSecret(provided: string): boolean {
+    if (!this.hash) return false;
+    const expected = Buffer.from(this.hash, "base64");
+    const actual = createHash("sha256").update(provided).digest();
+    return (
+      expected.length === actual.length && timingSafeEqual(expected, actual)
+    );
   }
 
   // Abstract method for backends to implement actual fetching logic

--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -147,7 +147,8 @@ export abstract class Backend<TRaw = unknown> {
   // Abstract method for backends to implement actual fetching logic
   abstract fetchReleases(): Promise<PecansReleases>;
 
-  // Return stream for an asset, serving out of the LRU cache if available.
+  // Serve an asset to the response (redirect or stream). Backends must
+  // override this to deliver the assets they created.
   async serveAsset(asset: PecansAssetDTO<TRaw>, res: Response) {
     throw Error("Abstract Method");
   }

--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -5,7 +5,7 @@ import { pipeline, Writable } from "stream";
 import { promisify } from "util";
 import { ForbiddenError } from "../errors";
 import { PecansReleases } from "../models";
-import { PecansAsset, PecansAssetDTO } from "../models/PecansAsset";
+import { PecansAssetDTO } from "../models/PecansAsset";
 
 const DEFAULT_CACHE_MAX_AGE = 60 * 60 * 2; // 2 hours in seconds
 
@@ -19,7 +19,11 @@ export class BackendSettings implements BackendOpts {
   public cacheMaxAge = DEFAULT_CACHE_MAX_AGE;
 }
 
-export abstract class Backend {
+// TRaw is the backend-private payload type this backend stashes on each
+// asset's `raw` field (e.g. the GitHub backend uses its API asset object),
+// giving the backend typed reads when assets flow back into serveAsset /
+// getAssetStream. Opaque (`unknown`) to everyone else.
+export abstract class Backend<TRaw = unknown> {
   protected opts: BackendSettings;
   private hash?: string;
   protected cache: PecansReleases | null = null;
@@ -100,6 +104,14 @@ export abstract class Backend {
         next();
         return;
       }
+      // the refresh contract is POST-only (matching the GitHub backend's
+      // webhook middleware); other methods fall through so crawlers hitting
+      // a shared ?secret= link can't trigger refreshes and preflights
+      // aren't answered with 403
+      if (req.method !== "POST") {
+        next();
+        return;
+      }
       // the middleware is mounted with use(), so req.params is never
       // populated here - the secret arrives as a header or query parameter
       const query = req.query.secret;
@@ -136,20 +148,20 @@ export abstract class Backend {
   abstract fetchReleases(): Promise<PecansReleases>;
 
   // Return stream for an asset, serving out of the LRU cache if available.
-  async serveAsset(asset: PecansAssetDTO, res: Response) {
+  async serveAsset(asset: PecansAssetDTO<TRaw>, res: Response) {
     throw Error("Abstract Method");
   }
 
   // Return stream for an asset
   async getAssetStream(
-    asset: PecansAsset,
+    asset: PecansAssetDTO<TRaw>,
   ): Promise<NodeJS.ReadableStream | null> {
     throw Error("Abstract Method");
   }
 
   // Return buffer for an asset stream
   // Requires Node.js 22+ for proper stream handling with pipeline()
-  async readAsset(asset: PecansAsset): Promise<Buffer> {
+  async readAsset(asset: PecansAssetDTO<TRaw>): Promise<Buffer> {
     const stream = await this.getAssetStream(asset);
     if (stream == null) {
       return Buffer.from("");

--- a/src/backends/github.ts
+++ b/src/backends/github.ts
@@ -42,7 +42,9 @@ export interface PecansGithubBackendEnvironment {
   GITHUB_TOKEN?: string;
 }
 
-export class PecansGitHubBackend extends Backend {
+// typed raw payload: assets created by this backend carry the GitHub API
+// asset object, read back in serveAsset/getAssetStream
+export class PecansGitHubBackend extends Backend<GithubReleaseAsset> {
   protected opts: PecansGitHubBackendSettings;
   protected octokit: Octokit;
 
@@ -167,7 +169,10 @@ export class PecansGitHubBackend extends Backend {
   }
 
   // Return stream for an asset
-  async serveAsset(asset: PecansAssetDTO, res: Response): Promise<void> {
+  async serveAsset(
+    asset: PecansAssetDTO<GithubReleaseAsset>,
+    res: Response,
+  ): Promise<void> {
     if (!this.opts.proxyAssets) {
       // raw is this backend's private payload: the GitHub API asset object
       const downloadUrl = asset.raw?.browser_download_url;
@@ -208,7 +213,7 @@ export class PecansGitHubBackend extends Backend {
   }
   // Return stream for an asset
   async getAssetStream(
-    asset: PecansAssetDTO,
+    asset: PecansAssetDTO<GithubReleaseAsset>,
   ): Promise<NodeJS.ReadableStream | null> {
     const headers: Record<string, string> = {
       "User-Agent": "pecans",
@@ -259,7 +264,8 @@ export class PecansGitHubBackend extends Backend {
           return undefined;
         }
       })
-      .filter(isPecansAsset);
+      // explicit type arg so the guard keeps the typed raw payload
+      .filter(isPecansAsset<GithubReleaseAsset>);
     const dto: PecansReleaseDTO = {
       version,
       channel,
@@ -270,7 +276,7 @@ export class PecansGitHubBackend extends Backend {
     return new PecansRelease(dto);
   }
 
-  normalizeAsset(asset: GithubReleaseAsset): PecansAsset {
+  normalizeAsset(asset: GithubReleaseAsset): PecansAsset<GithubReleaseAsset> {
     const id = asset.id.toString();
     const filename = asset.name;
     const type = filenameToPlatform(filename);

--- a/src/backends/github.ts
+++ b/src/backends/github.ts
@@ -169,7 +169,13 @@ export class PecansGitHubBackend extends Backend {
   // Return stream for an asset
   async serveAsset(asset: PecansAssetDTO, res: Response): Promise<void> {
     if (!this.opts.proxyAssets) {
-      res.redirect(asset.raw.browser_download_url);
+      // downloadUrl fallback for DTOs that predate the explicit URL fields
+      // (removed in 3.0)
+      const downloadUrl = asset.downloadUrl ?? asset.raw?.browser_download_url;
+      if (!downloadUrl) {
+        throw new Error(`Asset ${asset.id} has no downloadUrl`);
+      }
+      res.redirect(downloadUrl);
       return;
     } else {
       // native fetch follows redirects by default; "manual" returns the 302 so
@@ -183,8 +189,14 @@ export class PecansGitHubBackend extends Backend {
         headers["Authorization"] = `token ${this.token}`;
       }
       const options: RequestInit = { headers, redirect };
+      // apiUrl fallback for DTOs that predate the explicit URL fields
+      // (removed in 3.0)
+      const apiUrl = asset.apiUrl ?? asset.raw?.url;
+      if (!apiUrl) {
+        throw new Error(`Asset ${asset.id} has no apiUrl`);
+      }
       // get private url from github.
-      const assetRes = await fetch(asset.raw.url, options);
+      const assetRes = await fetch(apiUrl, options);
       const location = assetRes.headers.get("Location");
       if (location !== null) {
         // redirect user to limited use download url.
@@ -207,7 +219,12 @@ export class PecansGitHubBackend extends Backend {
       headers["Authorization"] = `token ${this.token}`;
     }
 
-    const url = asset.raw.url;
+    // apiUrl fallback for DTOs that predate the explicit URL fields
+    // (removed in 3.0)
+    const url = asset.apiUrl ?? asset.raw?.url;
+    if (!url) {
+      throw new Error(`Asset ${asset.id} has no apiUrl`);
+    }
     const opts: RequestInit = {
       method: "get",
       headers: headers,
@@ -267,6 +284,11 @@ export class PecansGitHubBackend extends Backend {
       type,
       size,
       content_type,
+      // explicit URLs so nothing downstream needs the GitHub-shaped raw:
+      // downloadUrl is the public redirect target, apiUrl the authenticated
+      // fetch target
+      downloadUrl: asset.browser_download_url,
+      apiUrl: asset.url,
       raw,
     };
     return new PecansAsset(dto);

--- a/src/backends/github.ts
+++ b/src/backends/github.ts
@@ -169,11 +169,12 @@ export class PecansGitHubBackend extends Backend {
   // Return stream for an asset
   async serveAsset(asset: PecansAssetDTO, res: Response): Promise<void> {
     if (!this.opts.proxyAssets) {
-      // downloadUrl fallback for DTOs that predate the explicit URL fields
-      // (removed in 3.0)
-      const downloadUrl = asset.downloadUrl ?? asset.raw?.browser_download_url;
+      // raw is this backend's private payload: the GitHub API asset object
+      const downloadUrl = asset.raw?.browser_download_url;
       if (!downloadUrl) {
-        throw new Error(`Asset ${asset.id} has no downloadUrl`);
+        throw new Error(
+          `Asset ${asset.id} has no browser_download_url in its raw payload`,
+        );
       }
       res.redirect(downloadUrl);
       return;
@@ -189,11 +190,10 @@ export class PecansGitHubBackend extends Backend {
         headers["Authorization"] = `token ${this.token}`;
       }
       const options: RequestInit = { headers, redirect };
-      // apiUrl fallback for DTOs that predate the explicit URL fields
-      // (removed in 3.0)
-      const apiUrl = asset.apiUrl ?? asset.raw?.url;
+      // raw is this backend's private payload: the GitHub API asset object
+      const apiUrl = asset.raw?.url;
       if (!apiUrl) {
-        throw new Error(`Asset ${asset.id} has no apiUrl`);
+        throw new Error(`Asset ${asset.id} has no url in its raw payload`);
       }
       // get private url from github.
       const assetRes = await fetch(apiUrl, options);
@@ -219,11 +219,10 @@ export class PecansGitHubBackend extends Backend {
       headers["Authorization"] = `token ${this.token}`;
     }
 
-    // apiUrl fallback for DTOs that predate the explicit URL fields
-    // (removed in 3.0)
-    const url = asset.apiUrl ?? asset.raw?.url;
+    // raw is this backend's private payload: the GitHub API asset object
+    const url = asset.raw?.url;
     if (!url) {
-      throw new Error(`Asset ${asset.id} has no apiUrl`);
+      throw new Error(`Asset ${asset.id} has no url in its raw payload`);
     }
     const opts: RequestInit = {
       method: "get",
@@ -284,11 +283,6 @@ export class PecansGitHubBackend extends Backend {
       type,
       size,
       content_type,
-      // explicit URLs so nothing downstream needs the GitHub-shaped raw:
-      // downloadUrl is the public redirect target, apiUrl the authenticated
-      // fetch target
-      downloadUrl: asset.browser_download_url,
-      apiUrl: asset.url,
       raw,
     };
     return new PecansAsset(dto);

--- a/src/backends/github.ts
+++ b/src/backends/github.ts
@@ -208,7 +208,10 @@ export class PecansGitHubBackend extends Backend<GithubReleaseAsset> {
         res.redirect(location);
         return;
       }
-      throw new Error("Unable to load asset url");
+      throw new Error(
+        `Unable to resolve download location for asset ${asset.id} ` +
+          `(${apiUrl}): HTTP ${assetRes.status} without a Location header`,
+      );
     }
   }
   // Return stream for an asset

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -22,6 +22,12 @@ export class BadRequestError extends HttpError {
   }
 }
 
+export class ForbiddenError extends HttpError {
+  constructor(message: string) {
+    super(message, 403);
+  }
+}
+
 export class NotFoundError extends HttpError {
   constructor(message: string) {
     super(message, 404);

--- a/src/models/PecansAsset.ts
+++ b/src/models/PecansAsset.ts
@@ -17,6 +17,23 @@ export interface PecansAssetDTO {
   content_type: string;
   filename: string;
   id: string;
+  /**
+   * Public URL clients can be redirected to for this asset. Backends should
+   * populate this explicitly; when absent, `PecansAsset` falls back to the
+   * GitHub-shaped `raw.browser_download_url` for compatibility with DTOs
+   * built before these fields existed (fallback removed in 3.0).
+   */
+  downloadUrl?: string;
+  /**
+   * Backend API URL for authenticated fetches of the asset content (e.g. the
+   * GitHub releases-asset API endpoint). Falls back to the GitHub-shaped
+   * `raw.url` when absent (fallback removed in 3.0).
+   */
+  apiUrl?: string;
+  /**
+   * Backend-specific payload the asset was normalized from. Kept for
+   * compatibility; prefer the explicit fields above.
+   */
   raw: any;
   size: number;
   // TODO:  use os, arch, and pkg in place of platform.
@@ -32,6 +49,8 @@ export class PecansAsset implements PecansAssetDTO {
   type: Platform;
   size: number;
   content_type: string;
+  downloadUrl?: string;
+  apiUrl?: string;
   raw: any;
 
   constructor(dto: PecansAssetDTO) {
@@ -41,6 +60,10 @@ export class PecansAsset implements PecansAssetDTO {
     this.raw = dto.raw;
     this.size = dto.size;
     this.type = dto.type;
+    // compat shim for DTOs that predate the explicit URL fields and only
+    // carry a GitHub-shaped raw payload (removed in 3.0)
+    this.downloadUrl = dto.downloadUrl ?? dto.raw?.browser_download_url;
+    this.apiUrl = dto.apiUrl ?? dto.raw?.url;
     this.os = filenameToOperatingSystem(this.filename);
     this.arch = filenameToArchitecture(this.filename, this.os);
     this.pkg = filenameToPackageFormat(this.filename);

--- a/src/models/PecansAsset.ts
+++ b/src/models/PecansAsset.ts
@@ -18,21 +18,19 @@ export interface PecansAssetDTO {
   filename: string;
   id: string;
   /**
-   * Public URL clients can be redirected to for this asset. Backends should
-   * populate this explicitly; when absent, `PecansAsset` falls back to the
-   * GitHub-shaped `raw.browser_download_url` for compatibility with DTOs
-   * built before these fields existed (fallback removed in 3.0).
+   * Public URL clients can be redirected to for this asset. Populated by the
+   * backend that normalizes the asset.
    */
   downloadUrl?: string;
   /**
    * Backend API URL for authenticated fetches of the asset content (e.g. the
-   * GitHub releases-asset API endpoint). Falls back to the GitHub-shaped
-   * `raw.url` when absent (fallback removed in 3.0).
+   * GitHub releases-asset API endpoint). Populated by the backend that
+   * normalizes the asset.
    */
   apiUrl?: string;
   /**
-   * Backend-specific payload the asset was normalized from. Kept for
-   * compatibility; prefer the explicit fields above.
+   * Backend-specific payload the asset was normalized from. Opaque outside
+   * the backend that created the asset; prefer the explicit fields above.
    */
   raw: any;
   size: number;
@@ -60,10 +58,10 @@ export class PecansAsset implements PecansAssetDTO {
     this.raw = dto.raw;
     this.size = dto.size;
     this.type = dto.type;
-    // compat shim for DTOs that predate the explicit URL fields and only
-    // carry a GitHub-shaped raw payload (removed in 3.0)
-    this.downloadUrl = dto.downloadUrl ?? dto.raw?.browser_download_url;
-    this.apiUrl = dto.apiUrl ?? dto.raw?.url;
+    // raw is backend-specific, so the neutral model never interprets it;
+    // legacy raw-only assets are handled by the backend that created them
+    this.downloadUrl = dto.downloadUrl;
+    this.apiUrl = dto.apiUrl;
     this.os = filenameToOperatingSystem(this.filename);
     this.arch = filenameToArchitecture(this.filename, this.os);
     this.pkg = filenameToPackageFormat(this.filename);

--- a/src/models/PecansAsset.ts
+++ b/src/models/PecansAsset.ts
@@ -13,7 +13,7 @@ import {
 } from "../utils/SupportedFileExtension";
 import { PecansAssetQuery } from "./PecansAssetQuery";
 
-export interface PecansAssetDTO {
+export interface PecansAssetDTO<TRaw = unknown> {
   content_type: string;
   filename: string;
   id: string;
@@ -21,15 +21,16 @@ export interface PecansAssetDTO {
    * Backend-private payload attached by the backend that created the asset
    * (e.g. the GitHub API asset object, which the GitHub backend reads back
    * in serveAsset/getAssetStream). Opaque outside that backend: core and
-   * other consumers must not interpret it.
+   * other consumers must not interpret it. Backends declare their payload
+   * type via TRaw (e.g. `Backend<GithubReleaseAsset>`) for typed reads.
    */
-  raw: any;
+  raw: TRaw;
   size: number;
   // TODO:  use os, arch, and pkg in place of platform.
   type: Platform;
 }
 
-export class PecansAsset implements PecansAssetDTO {
+export class PecansAsset<TRaw = unknown> implements PecansAssetDTO<TRaw> {
   os: OperatingSystem;
   arch: Architecture;
   pkg?: PackageFormat;
@@ -38,9 +39,9 @@ export class PecansAsset implements PecansAssetDTO {
   type: Platform;
   size: number;
   content_type: string;
-  raw: any;
+  raw: TRaw;
 
-  constructor(dto: PecansAssetDTO) {
+  constructor(dto: PecansAssetDTO<TRaw>) {
     this.content_type = dto.content_type;
     this.filename = dto.filename;
     this.id = dto.id;

--- a/src/models/PecansAsset.ts
+++ b/src/models/PecansAsset.ts
@@ -18,19 +18,10 @@ export interface PecansAssetDTO {
   filename: string;
   id: string;
   /**
-   * Public URL clients can be redirected to for this asset. Populated by the
-   * backend that normalizes the asset.
-   */
-  downloadUrl?: string;
-  /**
-   * Backend API URL for authenticated fetches of the asset content (e.g. the
-   * GitHub releases-asset API endpoint). Populated by the backend that
-   * normalizes the asset.
-   */
-  apiUrl?: string;
-  /**
-   * Backend-specific payload the asset was normalized from. Opaque outside
-   * the backend that created the asset; prefer the explicit fields above.
+   * Backend-private payload attached by the backend that created the asset
+   * (e.g. the GitHub API asset object, which the GitHub backend reads back
+   * in serveAsset/getAssetStream). Opaque outside that backend: core and
+   * other consumers must not interpret it.
    */
   raw: any;
   size: number;
@@ -47,8 +38,6 @@ export class PecansAsset implements PecansAssetDTO {
   type: Platform;
   size: number;
   content_type: string;
-  downloadUrl?: string;
-  apiUrl?: string;
   raw: any;
 
   constructor(dto: PecansAssetDTO) {
@@ -58,10 +47,6 @@ export class PecansAsset implements PecansAssetDTO {
     this.raw = dto.raw;
     this.size = dto.size;
     this.type = dto.type;
-    // raw is backend-specific, so the neutral model never interprets it;
-    // legacy raw-only assets are handled by the backend that created them
-    this.downloadUrl = dto.downloadUrl;
-    this.apiUrl = dto.apiUrl;
     this.os = filenameToOperatingSystem(this.filename);
     this.arch = filenameToArchitecture(this.filename, this.os);
     this.pkg = filenameToPackageFormat(this.filename);

--- a/src/models/PecansRelease.ts
+++ b/src/models/PecansRelease.ts
@@ -19,7 +19,11 @@ export interface PecansReleaseDTO {
   version: string;
 }
 
-export function isPecansAsset(obj: unknown): obj is PecansAsset {
+// generic so filtering keeps the caller's TRaw (e.g. the GitHub backend's
+// PecansAsset<GithubReleaseAsset>[] survives a .filter(isPecansAsset))
+export function isPecansAsset<TRaw = unknown>(
+  obj: unknown,
+): obj is PecansAsset<TRaw> {
   return obj instanceof PecansAsset;
 }
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2,6 +2,7 @@ import express from "express";
 import nock from "nock";
 import { GithubRelease } from "../src";
 import { Pecans, PecansGitHubBackend, PecansOptions } from "../src";
+import { Backend } from "../src/backends/backend";
 import { PecansGitHubBackendOpts } from "../src/backends/github";
 import { PecansAsset } from "../src/models";
 import { nockGithubListReleases } from "./nock/nockGithubListReleases";
@@ -21,7 +22,7 @@ export function configurePecansGitHubBackend(
 }
 
 export function configurePecansTestApp(
-  backend: PecansGitHubBackend,
+  backend: Backend,
   opts: PecansOptions = {},
 ) {
   const pecans = new Pecans(backend, opts);

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -2,12 +2,17 @@ import { Webhooks } from "@octokit/webhooks";
 import nock from "nock";
 import supertest from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Backend, BackendOpts } from "../../src/backends/backend";
+import { PecansReleases } from "../../src/models/PecansReleases";
 import {
   buildStableReleaseSet,
   buildRelease,
   buildFullPlatformAssets,
 } from "../fixtures/builders";
-import { configureTestAppWithReleases } from "../harness";
+import {
+  configurePecansTestApp,
+  configureTestAppWithReleases,
+} from "../harness";
 import { nockGithubListReleases } from "../nock/nockGithubListReleases";
 
 nock.disableNetConnect();
@@ -103,5 +108,65 @@ describe("/webhook/refresh (GitHub release webhook)", () => {
       .set("X-Hub-Signature-256", signature)
       .send(payload)
       .expect(404);
+  });
+});
+
+describe("/webhook/refresh (generic backend secret middleware)", () => {
+  // non-GitHub backends inherit the base Backend middleware, which
+  // authenticates via an X-Pecans-Secret header or ?secret= query parameter
+  class RefreshCountingBackend extends Backend {
+    public fetchCount = 0;
+    constructor(opts?: BackendOpts) {
+      super(opts);
+    }
+    async fetchReleases(): Promise<PecansReleases> {
+      this.fetchCount++;
+      return new PecansReleases([]);
+    }
+  }
+
+  function buildGenericApp(opts?: BackendOpts) {
+    const backend = new RefreshCountingBackend(opts);
+    const { app } = configurePecansTestApp(backend);
+    return { backend, app };
+  }
+
+  it("refreshes and responds 200 given the secret as a query parameter", async () => {
+    const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
+    const res = await supertest(app)
+      .post(`/webhook/refresh?secret=${SECRET}`)
+      .expect(200);
+    expect(res.body).toEqual({ refreshed: true });
+    expect(backend.fetchCount).toBe(1);
+  });
+
+  it("refreshes and responds 200 given the X-Pecans-Secret header", async () => {
+    const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
+    await supertest(app)
+      .post("/webhook/refresh")
+      .set("X-Pecans-Secret", SECRET)
+      .expect(200);
+    expect(backend.fetchCount).toBe(1);
+  });
+
+  it("responds 403 for a wrong secret without refreshing", async () => {
+    const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
+    const res = await supertest(app)
+      .post("/webhook/refresh?secret=wrong")
+      .expect(403);
+    expect(res.text).toContain("Invalid refresh secret");
+    expect(backend.fetchCount).toBe(0);
+  });
+
+  it("responds 403 when no secret is sent", async () => {
+    const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
+    await supertest(app).post("/webhook/refresh").expect(403);
+    expect(backend.fetchCount).toBe(0);
+  });
+
+  it("is a no-op 404 when no refreshSecret is configured", async () => {
+    const { backend, app } = buildGenericApp();
+    await supertest(app).post(`/webhook/refresh?secret=${SECRET}`).expect(404);
+    expect(backend.fetchCount).toBe(0);
   });
 });

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -164,6 +164,14 @@ describe("/webhook/refresh (generic backend secret middleware)", () => {
     expect(backend.fetchCount).toBe(0);
   });
 
+  // POST-only contract: a GET with a valid secret (e.g. a crawler following
+  // a shared ?secret= link) must fall through without refreshing
+  it("ignores non-POST requests even with a valid secret", async () => {
+    const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
+    await supertest(app).get(`/webhook/refresh?secret=${SECRET}`).expect(404);
+    expect(backend.fetchCount).toBe(0);
+  });
+
   it("is a no-op 404 when no refreshSecret is configured", async () => {
     const { backend, app } = buildGenericApp();
     await supertest(app).post(`/webhook/refresh?secret=${SECRET}`).expect(404);

--- a/test/unit/PecansAsset.spec.ts
+++ b/test/unit/PecansAsset.spec.ts
@@ -63,6 +63,41 @@ describe("PecansAsset", () => {
       );
       expect(asset.pkg).toBeUndefined();
     });
+
+    it("should carry explicit downloadUrl and apiUrl from the DTO", () => {
+      const asset = new PecansAsset(
+        createMockAssetDTO({
+          downloadUrl: "https://example.com/dl/app.dmg",
+          apiUrl: "https://api.example.com/assets/123",
+        }),
+      );
+      expect(asset.downloadUrl).toBe("https://example.com/dl/app.dmg");
+      expect(asset.apiUrl).toBe("https://api.example.com/assets/123");
+    });
+
+    // compat shim for DTOs that predate the explicit URL fields (removed in 3.0)
+    it("should fall back to the GitHub-shaped raw payload for missing URLs", () => {
+      const asset = new PecansAsset(
+        createMockAssetDTO({
+          raw: {
+            browser_download_url: "https://github.com/o/r/releases/d/app.dmg",
+            url: "https://api.github.com/repos/o/r/releases/assets/1",
+          },
+        }),
+      );
+      expect(asset.downloadUrl).toBe(
+        "https://github.com/o/r/releases/d/app.dmg",
+      );
+      expect(asset.apiUrl).toBe(
+        "https://api.github.com/repos/o/r/releases/assets/1",
+      );
+    });
+
+    it("should leave URLs undefined when neither DTO fields nor raw carry them", () => {
+      const asset = new PecansAsset(createMockAssetDTO());
+      expect(asset.downloadUrl).toBeUndefined();
+      expect(asset.apiUrl).toBeUndefined();
+    });
   });
 
   describe("satisfiesQuery", () => {

--- a/test/unit/PecansAsset.spec.ts
+++ b/test/unit/PecansAsset.spec.ts
@@ -75,8 +75,10 @@ describe("PecansAsset", () => {
       expect(asset.apiUrl).toBe("https://api.example.com/assets/123");
     });
 
-    // compat shim for DTOs that predate the explicit URL fields (removed in 3.0)
-    it("should fall back to the GitHub-shaped raw payload for missing URLs", () => {
+    // raw is backend-specific and opaque to the neutral model - even a
+    // GitHub-shaped raw payload must not leak into the explicit URL fields;
+    // legacy raw-only assets are interpreted by the backend that created them
+    it("should not derive URLs from the raw payload", () => {
       const asset = new PecansAsset(
         createMockAssetDTO({
           raw: {
@@ -85,16 +87,6 @@ describe("PecansAsset", () => {
           },
         }),
       );
-      expect(asset.downloadUrl).toBe(
-        "https://github.com/o/r/releases/d/app.dmg",
-      );
-      expect(asset.apiUrl).toBe(
-        "https://api.github.com/repos/o/r/releases/assets/1",
-      );
-    });
-
-    it("should leave URLs undefined when neither DTO fields nor raw carry them", () => {
-      const asset = new PecansAsset(createMockAssetDTO());
       expect(asset.downloadUrl).toBeUndefined();
       expect(asset.apiUrl).toBeUndefined();
     });

--- a/test/unit/PecansAsset.spec.ts
+++ b/test/unit/PecansAsset.spec.ts
@@ -64,31 +64,15 @@ describe("PecansAsset", () => {
       expect(asset.pkg).toBeUndefined();
     });
 
-    it("should carry explicit downloadUrl and apiUrl from the DTO", () => {
-      const asset = new PecansAsset(
-        createMockAssetDTO({
-          downloadUrl: "https://example.com/dl/app.dmg",
-          apiUrl: "https://api.example.com/assets/123",
-        }),
-      );
-      expect(asset.downloadUrl).toBe("https://example.com/dl/app.dmg");
-      expect(asset.apiUrl).toBe("https://api.example.com/assets/123");
-    });
-
-    // raw is backend-specific and opaque to the neutral model - even a
-    // GitHub-shaped raw payload must not leak into the explicit URL fields;
-    // legacy raw-only assets are interpreted by the backend that created them
-    it("should not derive URLs from the raw payload", () => {
-      const asset = new PecansAsset(
-        createMockAssetDTO({
-          raw: {
-            browser_download_url: "https://github.com/o/r/releases/d/app.dmg",
-            url: "https://api.github.com/repos/o/r/releases/assets/1",
-          },
-        }),
-      );
-      expect(asset.downloadUrl).toBeUndefined();
-      expect(asset.apiUrl).toBeUndefined();
+    // raw is backend-private: the model carries it verbatim for the backend
+    // that created the asset and never interprets it
+    it("should pass the raw payload through untouched", () => {
+      const raw = {
+        browser_download_url: "https://github.com/o/r/releases/d/app.dmg",
+        url: "https://api.github.com/repos/o/r/releases/assets/1",
+      };
+      const asset = new PecansAsset(createMockAssetDTO({ raw }));
+      expect(asset.raw).toBe(raw);
     });
   });
 

--- a/test/unit/backend-complete.spec.ts
+++ b/test/unit/backend-complete.spec.ts
@@ -59,6 +59,7 @@ describe("Backend Complete Coverage", () => {
     beforeEach(() => {
       mockReq = {
         path: "/api/refresh",
+        method: "POST",
         query: {},
         get: vi.fn().mockReturnValue(undefined),
       };
@@ -89,6 +90,20 @@ describe("Backend Complete Coverage", () => {
 
       expect(mockNext).toHaveBeenCalledWith();
       expect(mockNext).toHaveBeenCalledTimes(1);
+    });
+
+    // the refresh contract is POST-only; other methods fall through so a
+    // crawler hitting a shared ?secret= link can't trigger a refresh
+    it("should call next() for non-POST methods on the watched path", () => {
+      backend = new TestBackend({ refreshSecret: "test-secret" });
+      mockReq.method = "GET";
+      mockReq.query = { secret: "test-secret" };
+      const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
+
+      middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(mockRes.status).not.toHaveBeenCalled();
     });
 
     it("should 403 when the secret does not match", () => {

--- a/test/unit/backend-complete.spec.ts
+++ b/test/unit/backend-complete.spec.ts
@@ -5,6 +5,7 @@ import {
   BackendOpts,
   BackendSettings,
 } from "../../src/backends/backend";
+import { ForbiddenError } from "../../src/errors";
 import { PecansAsset, PecansAssetDTO } from "../../src/models/PecansAsset";
 import { PecansReleases } from "../../src/models/PecansReleases";
 
@@ -45,16 +46,27 @@ describe("Backend Complete Coverage", () => {
   describe("getRefreshWebhookMiddleware", () => {
     let backend: TestBackend;
     // express 5 declares Request.path readonly; the mock needs a mutable one
-    let mockReq: Omit<Partial<Request>, "path"> & { path?: string };
-    let mockRes: Partial<Response>;
+    let mockReq: Omit<Partial<Request>, "path" | "get"> & {
+      path?: string;
+      get: ReturnType<typeof vi.fn>;
+    };
+    let mockRes: Partial<Response> & {
+      status: ReturnType<typeof vi.fn>;
+      json: ReturnType<typeof vi.fn>;
+    };
     let mockNext: NextFunction;
 
     beforeEach(() => {
       mockReq = {
         path: "/api/refresh",
-        params: {},
+        query: {},
+        get: vi.fn().mockReturnValue(undefined),
       };
-      mockRes = {};
+      mockRes = {
+        status: vi.fn(),
+        json: vi.fn(),
+      };
+      mockRes.status.mockReturnValue(mockRes);
       mockNext = vi.fn();
     });
 
@@ -62,7 +74,7 @@ describe("Backend Complete Coverage", () => {
       backend = new TestBackend(); // No refreshSecret provided
       const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
-      middleware(mockReq as Request, mockRes as Response, mockNext);
+      middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalledWith();
       expect(mockNext).toHaveBeenCalledTimes(1);
@@ -73,57 +85,70 @@ describe("Backend Complete Coverage", () => {
       mockReq.path = "/different/path";
       const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
-      middleware(mockReq as Request, mockRes as Response, mockNext);
+      middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalledWith();
       expect(mockNext).toHaveBeenCalledTimes(1);
     });
 
-    it("should call next with 'bad secret' when secret does not match", () => {
+    it("should 403 when the secret does not match", () => {
       backend = new TestBackend({ refreshSecret: "test-secret" });
-      mockReq.params = { secret: "wrong-secret" };
+      mockReq.query = { secret: "wrong-secret" };
       const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
-      middleware(mockReq as Request, mockRes as Response, mockNext);
+      middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledWith("bad secret");
+      expect(mockNext).toHaveBeenCalledWith(expect.any(ForbiddenError));
     });
 
-    it("should refresh cache and call next() on successful validation", async () => {
-      const refreshSecret = "test-secret";
-      backend = new TestBackend({ refreshSecret });
+    it("should 403 when no secret is provided on the watched path", () => {
+      backend = new TestBackend({ refreshSecret: "test-secret" });
+      const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
-      // Calculate the expected hash that would be generated
-      const crypto = await import("crypto");
-      const expectedHash = crypto
-        .createHash("sha256")
-        .update(refreshSecret)
-        .digest("base64");
+      middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
 
-      mockReq.params = { secret: expectedHash };
+      expect(mockNext).toHaveBeenCalledWith(expect.any(ForbiddenError));
+    });
+
+    it("should refresh cache and respond 200 for a valid ?secret= query", async () => {
+      backend = new TestBackend({ refreshSecret: "test-secret" });
+      mockReq.query = { secret: "test-secret" };
 
       const refreshCacheSpy = vi
         .spyOn(backend, "refreshCache")
         .mockResolvedValue(backend.mockReleases);
       const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
-      await middleware(mockReq as Request, mockRes as Response, mockNext);
+      middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
+      await vi.waitFor(() => expect(mockRes.json).toHaveBeenCalled());
 
       expect(refreshCacheSpy).toHaveBeenCalled();
-      expect(mockNext).toHaveBeenCalledWith();
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({ refreshed: true });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should accept the secret from the X-Pecans-Secret header", async () => {
+      backend = new TestBackend({ refreshSecret: "test-secret" });
+      mockReq.get.mockImplementation((name: string) =>
+        name.toLowerCase() === "x-pecans-secret" ? "test-secret" : undefined,
+      );
+
+      const refreshCacheSpy = vi
+        .spyOn(backend, "refreshCache")
+        .mockResolvedValue(backend.mockReleases);
+      const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
+
+      middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
+      await vi.waitFor(() => expect(mockRes.json).toHaveBeenCalled());
+
+      expect(refreshCacheSpy).toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(200);
     });
 
     it("should call next with error when refreshCache fails", async () => {
-      const refreshSecret = "test-secret";
-      backend = new TestBackend({ refreshSecret });
-
-      const crypto = await import("crypto");
-      const expectedHash = crypto
-        .createHash("sha256")
-        .update(refreshSecret)
-        .digest("base64");
-
-      mockReq.params = { secret: expectedHash };
+      backend = new TestBackend({ refreshSecret: "test-secret" });
+      mockReq.query = { secret: "test-secret" };
 
       const testError = new Error("Cache refresh failed");
       const refreshCacheSpy = vi
@@ -132,13 +157,12 @@ describe("Backend Complete Coverage", () => {
       const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
       // The middleware is not async, but refreshCache is, so we need to wait
-      middleware(mockReq as Request, mockRes as Response, mockNext);
-
-      // Wait a bit for the promise to resolve
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
+      await vi.waitFor(() => expect(mockNext).toHaveBeenCalled());
 
       expect(refreshCacheSpy).toHaveBeenCalled();
       expect(mockNext).toHaveBeenCalledWith(testError);
+      expect(mockRes.json).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/github.spec.ts
+++ b/test/unit/github.spec.ts
@@ -372,7 +372,30 @@ describe("PecansGitHubBackend", () => {
       };
     });
 
-    it("should redirect to browser_download_url when not proxying", async () => {
+    it("should redirect to downloadUrl when not proxying", async () => {
+      backend = new PecansGitHubBackend("owner", "repo", "token", {
+        proxyAssets: false,
+      });
+
+      const asset = {
+        id: "1",
+        type: "windows_64" as const,
+        filename: "app.exe",
+        size: 1000,
+        content_type: "application/octet-stream",
+        downloadUrl:
+          "https://github.com/owner/repo/releases/download/v1.0.0/app.exe",
+        raw: {},
+      };
+
+      await backend.serveAsset(asset, mockResponse as Response);
+
+      expect(mockResponse.redirect).toHaveBeenCalledWith(asset.downloadUrl);
+    });
+
+    // compat: DTOs built before the explicit URL fields only carry the
+    // GitHub-shaped raw payload (fallback removed in 3.0)
+    it("should fall back to raw.browser_download_url when downloadUrl is absent", async () => {
       backend = new PecansGitHubBackend("owner", "repo", "token", {
         proxyAssets: false,
       });
@@ -396,6 +419,25 @@ describe("PecansGitHubBackend", () => {
       );
     });
 
+    it("should throw when neither downloadUrl nor raw carries a url", async () => {
+      backend = new PecansGitHubBackend("owner", "repo", "token", {
+        proxyAssets: false,
+      });
+
+      const asset = {
+        id: "1",
+        type: "windows_64" as const,
+        filename: "app.exe",
+        size: 1000,
+        content_type: "application/octet-stream",
+        raw: {},
+      };
+
+      await expect(
+        backend.serveAsset(asset, mockResponse as Response),
+      ).rejects.toThrow("no downloadUrl");
+    });
+
     it("should fetch and redirect to location when proxying", async () => {
       backend = new PecansGitHubBackend("owner", "repo", "token", {
         proxyAssets: true,
@@ -407,9 +449,8 @@ describe("PecansGitHubBackend", () => {
         filename: "app.exe",
         size: 1000,
         content_type: "application/octet-stream",
-        raw: {
-          url: "https://api.github.com/repos/owner/repo/releases/assets/1",
-        },
+        apiUrl: "https://api.github.com/repos/owner/repo/releases/assets/1",
+        raw: {},
       };
 
       const mockFetchResponse = {
@@ -481,9 +522,8 @@ describe("PecansGitHubBackend", () => {
         filename: "app.exe",
         size: 1000,
         content_type: "application/octet-stream",
-        raw: {
-          url: "https://api.github.com/repos/owner/repo/releases/assets/1",
-        },
+        apiUrl: "https://api.github.com/repos/owner/repo/releases/assets/1",
+        raw: {},
       };
 
       // native fetch resolves `body` to a web ReadableStream; the backend wraps
@@ -499,7 +539,7 @@ describe("PecansGitHubBackend", () => {
 
       const result = await backend.getAssetStream(asset);
 
-      expect(mockFetch).toHaveBeenCalledWith(asset.raw.url, {
+      expect(mockFetch).toHaveBeenCalledWith(asset.apiUrl, {
         method: "get",
         headers: {
           "User-Agent": "pecans",
@@ -515,6 +555,7 @@ describe("PecansGitHubBackend", () => {
       expect(Buffer.concat(chunks).toString()).toBe("payload");
     });
 
+    // compat: raw-only DTO exercises the raw.url fallback (removed in 3.0)
     it("should fetch asset stream without token", async () => {
       backend = new PecansGitHubBackend("owner", "repo");
 
@@ -705,6 +746,8 @@ describe("PecansGitHubBackend", () => {
         size: 1000,
         content_type: "application/octet-stream",
         url: "https://api.github.com/repos/owner/repo/releases/assets/123",
+        browser_download_url:
+          "https://github.com/owner/repo/releases/download/v1.0.0/app-v1.0.0-win32-x64.exe",
       };
 
       const result = backend.normalizeAsset(githubAsset as any);
@@ -714,6 +757,9 @@ describe("PecansGitHubBackend", () => {
       expect(result.type).toBe("windows_32");
       expect(result.size).toBe(1000);
       expect(result.content_type).toBe("application/octet-stream");
+      // explicit URLs are populated so nothing downstream reads raw
+      expect(result.downloadUrl).toBe(githubAsset.browser_download_url);
+      expect(result.apiUrl).toBe(githubAsset.url);
       expect(result.raw).toBe(githubAsset);
     });
   });

--- a/test/unit/github.spec.ts
+++ b/test/unit/github.spec.ts
@@ -477,15 +477,21 @@ describe("PecansGitHubBackend", () => {
       };
 
       const mockFetchResponse = {
+        status: 404,
         headers: {
           get: vi.fn().mockReturnValue(null),
         },
       } as any;
       mockFetch.mockResolvedValue(mockFetchResponse);
 
+      // the error carries the asset id, api url, and status for diagnosis
       await expect(
         backend.serveAsset(asset, mockResponse as Response),
-      ).rejects.toThrow("Unable to load asset url");
+      ).rejects.toThrow(
+        "Unable to resolve download location for asset 1 " +
+          "(https://api.github.com/repos/owner/repo/releases/assets/1): " +
+          "HTTP 404 without a Location header",
+      );
     });
   });
 

--- a/test/unit/github.spec.ts
+++ b/test/unit/github.spec.ts
@@ -4,6 +4,7 @@ import { Response } from "express";
 import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  GithubReleaseAsset,
   GitHubBackend,
   PecansGitHubBackend,
   PecansGitHubBackendSettings,
@@ -386,7 +387,7 @@ describe("PecansGitHubBackend", () => {
         raw: {
           browser_download_url:
             "https://github.com/owner/repo/releases/download/v1.0.0/app.exe",
-        },
+        } as GithubReleaseAsset,
       };
 
       await backend.serveAsset(asset, mockResponse as Response);
@@ -407,7 +408,7 @@ describe("PecansGitHubBackend", () => {
         filename: "app.exe",
         size: 1000,
         content_type: "application/octet-stream",
-        raw: {},
+        raw: {} as GithubReleaseAsset,
       };
 
       await expect(
@@ -428,7 +429,7 @@ describe("PecansGitHubBackend", () => {
         content_type: "application/octet-stream",
         raw: {
           url: "https://api.github.com/repos/owner/repo/releases/assets/1",
-        },
+        } as GithubReleaseAsset,
       };
 
       const mockFetchResponse = {
@@ -472,7 +473,7 @@ describe("PecansGitHubBackend", () => {
         content_type: "application/octet-stream",
         raw: {
           url: "https://api.github.com/repos/owner/repo/releases/assets/1",
-        },
+        } as GithubReleaseAsset,
       };
 
       const mockFetchResponse = {
@@ -502,7 +503,7 @@ describe("PecansGitHubBackend", () => {
         content_type: "application/octet-stream",
         raw: {
           url: "https://api.github.com/repos/owner/repo/releases/assets/1",
-        },
+        } as GithubReleaseAsset,
       };
 
       // native fetch resolves `body` to a web ReadableStream; the backend wraps
@@ -545,7 +546,7 @@ describe("PecansGitHubBackend", () => {
         content_type: "application/octet-stream",
         raw: {
           url: "https://api.github.com/repos/owner/repo/releases/assets/1",
-        },
+        } as GithubReleaseAsset,
       };
 
       const mockBody = new ReadableStream<Uint8Array>({

--- a/test/unit/github.spec.ts
+++ b/test/unit/github.spec.ts
@@ -372,30 +372,7 @@ describe("PecansGitHubBackend", () => {
       };
     });
 
-    it("should redirect to downloadUrl when not proxying", async () => {
-      backend = new PecansGitHubBackend("owner", "repo", "token", {
-        proxyAssets: false,
-      });
-
-      const asset = {
-        id: "1",
-        type: "windows_64" as const,
-        filename: "app.exe",
-        size: 1000,
-        content_type: "application/octet-stream",
-        downloadUrl:
-          "https://github.com/owner/repo/releases/download/v1.0.0/app.exe",
-        raw: {},
-      };
-
-      await backend.serveAsset(asset, mockResponse as Response);
-
-      expect(mockResponse.redirect).toHaveBeenCalledWith(asset.downloadUrl);
-    });
-
-    // compat: DTOs built before the explicit URL fields only carry the
-    // GitHub-shaped raw payload (fallback removed in 3.0)
-    it("should fall back to raw.browser_download_url when downloadUrl is absent", async () => {
+    it("should redirect to the raw payload's browser_download_url when not proxying", async () => {
       backend = new PecansGitHubBackend("owner", "repo", "token", {
         proxyAssets: false,
       });
@@ -419,7 +396,7 @@ describe("PecansGitHubBackend", () => {
       );
     });
 
-    it("should throw when neither downloadUrl nor raw carries a url", async () => {
+    it("should throw a clear error when the raw payload has no download url", async () => {
       backend = new PecansGitHubBackend("owner", "repo", "token", {
         proxyAssets: false,
       });
@@ -435,7 +412,7 @@ describe("PecansGitHubBackend", () => {
 
       await expect(
         backend.serveAsset(asset, mockResponse as Response),
-      ).rejects.toThrow("no downloadUrl");
+      ).rejects.toThrow("no browser_download_url");
     });
 
     it("should fetch and redirect to location when proxying", async () => {
@@ -449,8 +426,9 @@ describe("PecansGitHubBackend", () => {
         filename: "app.exe",
         size: 1000,
         content_type: "application/octet-stream",
-        apiUrl: "https://api.github.com/repos/owner/repo/releases/assets/1",
-        raw: {},
+        raw: {
+          url: "https://api.github.com/repos/owner/repo/releases/assets/1",
+        },
       };
 
       const mockFetchResponse = {
@@ -522,8 +500,9 @@ describe("PecansGitHubBackend", () => {
         filename: "app.exe",
         size: 1000,
         content_type: "application/octet-stream",
-        apiUrl: "https://api.github.com/repos/owner/repo/releases/assets/1",
-        raw: {},
+        raw: {
+          url: "https://api.github.com/repos/owner/repo/releases/assets/1",
+        },
       };
 
       // native fetch resolves `body` to a web ReadableStream; the backend wraps
@@ -539,7 +518,7 @@ describe("PecansGitHubBackend", () => {
 
       const result = await backend.getAssetStream(asset);
 
-      expect(mockFetch).toHaveBeenCalledWith(asset.apiUrl, {
+      expect(mockFetch).toHaveBeenCalledWith(asset.raw.url, {
         method: "get",
         headers: {
           "User-Agent": "pecans",
@@ -555,7 +534,6 @@ describe("PecansGitHubBackend", () => {
       expect(Buffer.concat(chunks).toString()).toBe("payload");
     });
 
-    // compat: raw-only DTO exercises the raw.url fallback (removed in 3.0)
     it("should fetch asset stream without token", async () => {
       backend = new PecansGitHubBackend("owner", "repo");
 
@@ -757,9 +735,7 @@ describe("PecansGitHubBackend", () => {
       expect(result.type).toBe("windows_32");
       expect(result.size).toBe(1000);
       expect(result.content_type).toBe("application/octet-stream");
-      // explicit URLs are populated so nothing downstream reads raw
-      expect(result.downloadUrl).toBe(githubAsset.browser_download_url);
-      expect(result.apiUrl).toBe(githubAsset.url);
+      // raw carries the full GitHub asset for this backend's later use
       expect(result.raw).toBe(githubAsset);
     });
   });


### PR DESCRIPTION
## Summary

First of the three Phase 7 PRs (backend abstraction → resolution pipeline → HTTP split). This one clarifies the backend↔core contract and fixes a broken endpoint; HTTP behavior of all download/update routes is unchanged (Phase 1 contract suite passes untouched).

### Backend contract: `raw` is the backend-private slot, typed via `TRaw`

An asset is only ever served by the backend that created it — `serveAsset`/`getAssetStream` are abstract `Backend` methods that core always delegates to — so per-backend serving state is that backend's internal detail, not public model surface. The PR encodes that instead of adding new public fields:

- `PecansAssetDTO.raw` is documented as the **backend-private slot**: the backend that normalizes an asset may stash whatever it needs there, and core and other consumers must not interpret it. This is the pattern the codebase has had since 1.x, now stated as a rule.
- `PecansAssetDTO<TRaw = unknown>` / `PecansAsset<TRaw = unknown>` / `Backend<TRaw = unknown>`: a backend declares its payload type once (`PecansGitHubBackend extends Backend<GithubReleaseAsset>`) and gets fully typed `raw` reads back in `serveAsset`/`getAssetStream` — no subclassing of the model needed. At the neutral default `raw` is `unknown`, so consumers must narrow instead of dot-accessing what used to be `any`. **Type-level change only; zero runtime difference.** (Type-level break: code reading `asset.raw.foo` against the neutral type no longer compiles — that's the hint safety this buys.)
- The GitHub backend's reads of its own `raw` gain **clear missing-field errors** (`Asset 123 has no browser_download_url in its raw payload`) instead of crashing with `Cannot read properties of undefined` on malformed assets.

> An earlier iteration of this PR added public `downloadUrl`/`apiUrl` fields to the DTO; review discussion concluded that was itself a leaky abstraction (core never needs them, and they would grow the already-serialized `/api/versions` asset JSON), so it was reverted in favor of the documented-opaque-`raw` contract.

### Fix: generic refresh webhook could never authenticate

The base `Backend.getRefreshWebhookMiddleware` compared the stored secret hash against `req.params.secret` — which is never populated on `use()`-mounted middleware, so any request with a configured `refreshSecret` failed. Now:

- **POST-only** on the watched path (matching the GitHub webhook middleware); other methods fall through, so crawlers following a shared `?secret=` link can't trigger refreshes (Copilot review finding).
- The secret arrives via an **`X-Pecans-Secret` header or `?secret=` query parameter** (the middleware has no route params to read).
- Comparison is **constant-time** (`crypto.timingSafeEqual` over sha256 digests).
- Mismatch → **403** via a new `ForbiddenError` (exported, slots into the Phase 6 error hierarchy); success → **200 `{"refreshed": true}`**.
- No `refreshSecret` configured → pass-through (endpoint stays disabled), unchanged.

The GitHub backend's override (signed-payload verification via `@octokit/webhooks`) is untouched. Documented in a new README "Cache-refresh webhook" section.

### Verification
- `npm test`: 31 files / **717 passed** (new coverage: webhook middleware unit + e2e tests through the router's error handler, POST-only gate, raw-passthrough and missing-url error pins)
- lint, typecheck, format, build green
- packed tarball smoke-tested from CJS and ESM, plus a strict-mode TS consumer check: `TRaw` inference works, neutral `raw` is `unknown` (dot access fails to compile), `PecansGitHubBackend` still satisfies the neutral `Backend` slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zUyj4PpSog9RkrYxzFRhM