### PR TITLE
feat!: strip backend-private payloads from API responses

### DIFF
--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -12,7 +12,15 @@ export function createApiChannelsHandler(ctx: PecansHttpContext) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       const releases = await ctx.getReleases();
-      const channels = releases.getChannels();
+      // public shape only: the full PecansChannel embeds every release (and
+      // latest_release) recursively, which bloats the payload; module
+      // consumers keep the rich objects via getChannels()
+      const channels = releases.getChannels().map((channel) => ({
+        name: channel.name,
+        latest: channel.latest,
+        versions_count: channel.versions_count,
+        published_at: channel.published_at,
+      }));
       res.json(channels);
     } catch (err) {
       next(err);

--- a/src/models/PecansAsset.ts
+++ b/src/models/PecansAsset.ts
@@ -71,8 +71,10 @@ export class PecansAsset<TRaw = unknown> implements PecansAssetDTO<TRaw> {
     arch: Architecture;
     pkg?: PackageFormat;
   } {
-    const { raw: _raw, ...pub } = this;
-    return pub;
+    // explicit allowlist rather than a rest-spread denylist, so a future
+    // private field can never leak by omission
+    const { os, arch, pkg, id, filename, type, size, content_type } = this;
+    return { os, arch, pkg, id, filename, type, size, content_type };
   }
 
   satisfiesQuery(query: PecansAssetQuery) {

--- a/src/models/PecansAsset.ts
+++ b/src/models/PecansAsset.ts
@@ -59,6 +59,22 @@ export class PecansAsset<TRaw = unknown> implements PecansAssetDTO<TRaw> {
     this.pkg = filenameToPackageFormat(this.filename);
   }
 
+  /**
+   * Public serialization shape: everything except `raw`. raw is the
+   * backend-private payload (for the GitHub backend, the full API asset
+   * object including uploader identity and API urls) and must never leak
+   * through JSON surfaces like /api/versions - especially when pecans
+   * fronts a private repository.
+   */
+  toJSON(): Omit<PecansAssetDTO, "raw"> & {
+    os: OperatingSystem;
+    arch: Architecture;
+    pkg?: PackageFormat;
+  } {
+    const { raw: _raw, ...pub } = this;
+    return pub;
+  }
+
   satisfiesQuery(query: PecansAssetQuery) {
     return (
       this.satisfiesOS(query.os) &&

--- a/test/integration/api.spec.ts
+++ b/test/integration/api.spec.ts
@@ -28,6 +28,22 @@ describe("/api/channels", () => {
     expect(stable.versions_count).toBe(3);
   });
 
+  // the full PecansChannel embeds every release recursively; the public
+  // payload is the slim summary only
+  it("serves the slim public channel shape without embedded releases", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app).get("/api/channels").expect(200);
+    const [stable] = res.body;
+    expect(Object.keys(stable).sort()).toEqual([
+      "latest",
+      "name",
+      "published_at",
+      "versions_count",
+    ]);
+  });
+
   it("lists every channel when prereleases exist", async () => {
     const { app } = configureTestAppWithReleases(
       buildMixedChannelReleaseSet(OWNER, REPO),
@@ -50,6 +66,27 @@ describe("/api/versions", () => {
     const res = await supertest(app).get("/api/versions").expect(200);
     const versions = res.body.map((r: { version: string }) => r.version);
     expect(versions).toEqual(["2.7.0", "2.6.0", "2.5.0"]);
+  });
+
+  // raw is the backend-private payload (the GitHub API asset object,
+  // including uploader identity and API urls); it must never serialize
+  // into API responses, especially for servers fronting private repos
+  it("never exposes the backend-private raw payload on assets", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app).get("/api/versions").expect(200);
+    const assets = res.body.flatMap(
+      (release: { assets: Record<string, unknown>[] }) => release.assets,
+    );
+    expect(assets.length).toBeGreaterThan(0);
+    for (const asset of assets) {
+      expect(asset).not.toHaveProperty("raw");
+      // the discrete platform fields remain part of the public shape
+      expect(asset).toHaveProperty("os");
+      expect(asset).toHaveProperty("arch");
+      expect(asset).toHaveProperty("filename");
+    }
   });
 
   it("?channel filters to that channel", async () => {


### PR DESCRIPTION
## Summary

PR 4 of the 2.0 release-review series.

Every asset carried `raw` — for the GitHub backend, the **full API asset object** including uploader identity, node ids, and API urls — and `/api/versions` serialized it verbatim. `/api/channels` additionally embedded every release (and `latest_release`) recursively. For a server whose purpose is fronting **private** repositories, that's a metadata leak and serious payload bloat.

## Changes

- `PecansAsset` gains `toJSON()` that omits `raw` while keeping the public fields plus the discrete `os`/`arch`/`pkg`. Anything that JSON-serializes assets (`/api/versions`, host apps doing `res.json(release)`) now emits the clean shape automatically.
- `/api/channels` returns the slim `{name, latest, versions_count, published_at}` summary instead of the recursive channel objects.
- Module consumers unaffected: `getChannels()` and the model objects keep their full shape in memory, and backends still read `asset.raw` directly for `serveAsset`/`getAssetStream`.
- Two integration regressions, verified red against the old code: no `raw` anywhere in `/api/versions`; `/api/channels` entries have exactly the four public keys.

**BREAKING CHANGE:** `/api/versions` asset objects no longer include `raw`, and `/api/channels` entries no longer include `releases`/`latest_release`. Clients that need a download should use the `/download` or `/dl` routes rather than `raw.browser_download_url`.

## Testing

- `npm test` — 803 passed (33 files)
- `npm run lint`, `npm run typecheck`, `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ)_