### PR TITLE
feat!: first-class windows and linux arm64 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Pecans is an Electron Release Server.
 ## Features
 
 - Download URLs (the client chooses the platform; user-agent autodetection was removed in 2.0)
-  - `/download/:platform` — latest build for a platform (`osx_64`, `windows_64`, … legacy aliases like `darwin`, `win32`, `mac-arm64` are accepted)
+  - `/download/:platform` — latest build for a platform (`osx_64`, `windows_64`, `windows_arm64`, `linux_arm64`, … legacy and update.electronjs.org-style aliases like `darwin`, `win32`, `mac-arm64`, `win32-arm64`, `linux-arm64` are accepted; bare-os requests such as `/download/windows` never default to an arm64 build)
   - `/download/channel/:channel/:platform` — latest build on a release channel
   - `/download/version/:tag/:platform` — a specific version
   - `/download/:tag/:filename` — a specific release asset by filename
-  - `/dl/:os/:arch` — resolve by discrete OS (`osx`, `windows`, `linux`) and arch (`32`, `64`, `arm64`, `universal`); supports `?channel`, `?version`, and `?pkg` (`deb`/`rpm`) queries
+  - `/dl/:os/:arch` — resolve by discrete OS (`osx`, `windows`, `linux`) and arch (`32`, `64`, `arm64`, `universal`; arm64 is supported for all three OSes since 2.0); supports `?channel`, `?version`, and `?pkg` (`deb`/`rpm`) queries
   - `/dl/:filename` — a release asset by filename
 - Auto-updates with [Squirrel](https://github.com/Squirrel)
   - For Mac using Squirrel.Mac

--- a/src/service.ts
+++ b/src/service.ts
@@ -111,6 +111,17 @@ export function resolveAssetForRelease(
   });
 
   const sorted = candidates.sort((a1, a2) => {
+    // an unconstrained-arch query never defaults to arm64: bare-os requests
+    // ("/download/windows") serve the broad x64/universal population, so
+    // arm64 builds rank last unless the filter asks for them - without
+    // this, the specificity rule below would prefer "windows_arm64" over
+    // "windows_64" purely by string length
+    if (!filter.arch) {
+      const a1arm = parsePlatform(a1.type).arch === "arm64" ? 1 : 0;
+      const a2arm = parsePlatform(a2.type).arch === "arm64" ? 1 : 0;
+      if (a1arm !== a2arm) return a1arm - a2arm;
+    }
+
     // more specific composite platform ids win ("osx_universal" >
     // "osx_arm64" > "osx_64" > "osx") - legacy ordering preserved verbatim;
     // candidates are already narrowed to the requested platform, so this

--- a/src/utils/Architecture.ts
+++ b/src/utils/Architecture.ts
@@ -48,10 +48,10 @@ export function getSupportedArchByOs(os: OperatingSystem): Architecture[] {
     case "osx":
       return ["64", "32", "arm64", "universal"];
     case "windows":
-      return ["32", "64", "universal"];
+      return ["32", "64", "arm64", "universal"];
     case "linux":
     default:
-      return ["32", "64"];
+      return ["32", "64", "arm64"];
   }
 }
 

--- a/src/utils/platforms.ts
+++ b/src/utils/platforms.ts
@@ -21,12 +21,15 @@ export const PLATFORMS = [
   "linux",
   "linux_32",
   "linux_64",
+  "linux_arm64",
   "linux_rpm",
   "linux_rpm_32",
   "linux_rpm_64",
+  "linux_rpm_arm64",
   "linux_deb",
   "linux_deb_32",
   "linux_deb_64",
+  "linux_deb_arm64",
   "osx",
   "osx_universal",
   "osx_32",
@@ -35,9 +38,11 @@ export const PLATFORMS = [
   "windows",
   "windows_32",
   "windows_64",
+  "windows_arm64",
   "windows_msix",
   "windows_msix_32",
   "windows_msix_64",
+  "windows_msix_arm64",
   "windows_msix_universal",
 ] as const;
 
@@ -48,12 +53,15 @@ export const platforms: Record<string, Platform> = {
   LINUX: "linux",
   LINUX_32: "linux_32",
   LINUX_64: "linux_64",
+  LINUX_ARM64: "linux_arm64",
   LINUX_RPM: "linux_rpm",
   LINUX_RPM_32: "linux_rpm_32",
   LINUX_RPM_64: "linux_rpm_64",
+  LINUX_RPM_ARM64: "linux_rpm_arm64",
   LINUX_DEB: "linux_deb",
   LINUX_DEB_32: "linux_deb_32",
   LINUX_DEB_64: "linux_deb_64",
+  LINUX_DEB_ARM64: "linux_deb_arm64",
   OSX: "osx",
   OSX_32: "osx_32",
   OSX_64: "osx_64",
@@ -62,12 +70,14 @@ export const platforms: Record<string, Platform> = {
   WINDOWS: "windows",
   WINDOWS_32: "windows_32",
   WINDOWS_64: "windows_64",
+  WINDOWS_ARM64: "windows_arm64",
   WINDOWS_MSIX: "windows_msix",
   WINDOWS_MSIX_32: "windows_msix_32",
   WINDOWS_MSIX_64: "windows_msix_64",
+  WINDOWS_MSIX_ARM64: "windows_msix_arm64",
   // .msixbundle is a multi-architecture bundle by definition, so it ingests
-  // as universal; there is no arm64 windows platform, so single-arch arm64
-  // .msix assets are dropped at ingestion like any other arm64 windows asset
+  // as universal; single-arch arm64 .msix assets ingest as
+  // windows_msix_arm64
   WINDOWS_MSIX_UNIVERSAL: "windows_msix_universal",
 };
 
@@ -97,6 +107,11 @@ export const legacyPlatformMap: Record<string, Platform> = {
   win32: platforms.WINDOWS_32,
   "win32-x64": platforms.WINDOWS_64,
   "win32-amd64": platforms.WINDOWS_64,
+  // update.electronjs.org-style arm64 ids
+  "win-arm64": platforms.WINDOWS_ARM64,
+  "win32-arm64": platforms.WINDOWS_ARM64,
+  "windows-arm64": platforms.WINDOWS_ARM64,
+  "linux-arm64": platforms.LINUX_ARM64,
 };
 
 export function mapLegacyPlatform(platform: string): string {

--- a/test/integration/dl.spec.ts
+++ b/test/integration/dl.spec.ts
@@ -2,7 +2,10 @@ import nock from "nock";
 import supertest from "supertest";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  buildAsset,
+  buildFullPlatformAssets,
   buildMixedChannelReleaseSet,
+  buildRelease,
   buildStableReleaseSet,
 } from "../fixtures/builders.js";
 import { configureTestAppWithReleases, findAsset } from "../harness.js";
@@ -39,6 +42,35 @@ describe("/dl/:os/:arch", () => {
     nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
     const res = await supertest(app).get(url).expect(302);
     expect(res.headers.location).toContain(filename);
+  });
+
+  it("serves windows and linux arm64 assets", async () => {
+    // arm64 assets alongside the standard fixture set; previously these
+    // were dropped at ingestion (no windows_arm64/linux_arm64 platforms)
+    const version = "3.0.0";
+    const release = buildRelease({
+      owner: OWNER,
+      repo: REPO,
+      version,
+      assets: [
+        ...buildFullPlatformAssets(OWNER, REPO, version),
+        buildAsset(OWNER, REPO, `app-${version}-win32-arm64-setup.exe`),
+        buildAsset(OWNER, REPO, `app-${version}-linux-arm64.tar.gz`),
+      ],
+    });
+    const { app, backend } = configureTestAppWithReleases([release]);
+
+    for (const [url, filename] of [
+      ["/dl/windows/arm64", `app-${version}-win32-arm64-setup.exe`],
+      ["/dl/linux/arm64", `app-${version}-linux-arm64.tar.gz`],
+      // the x64 defaults keep resolving despite the arm64 assets
+      ["/dl/windows/64", `app-${version}-x64-setup.exe`],
+    ] as const) {
+      const asset = await findAsset(backend, version, filename);
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+      const res = await supertest(app).get(url).expect(302);
+      expect(res.headers.location).toContain(filename);
+    }
   });
 
   it("?version selects an older release", async () => {
@@ -89,7 +121,8 @@ describe("/dl/:os/:arch", () => {
     const { app } = configureTestAppWithReleases(
       buildStableReleaseSet(OWNER, REPO),
     );
-    const res = await supertest(app).get("/dl/linux/arm64").expect(404);
+    // linux has no universal builds (arm64 became a valid linux arch in 2.0)
+    const res = await supertest(app).get("/dl/linux/universal").expect(404);
     expect(res.text).toContain("Unsupported Arch");
   });
 

--- a/test/integration/download.spec.ts
+++ b/test/integration/download.spec.ts
@@ -2,6 +2,7 @@ import nock from "nock";
 import supertest from "supertest";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  buildAsset,
   buildFullPlatformAssets,
   buildMixedChannelReleaseSet,
   buildRelease,
@@ -82,6 +83,31 @@ describe("/download/:platform?", () => {
       await expectRedirectTo(app, `/download/${platform}`, filename);
     },
   );
+
+  it("serves arm64 via alias but never as the bare-os default", async () => {
+    const version = "3.0.0";
+    const release = buildRelease({
+      owner: OWNER,
+      repo: REPO,
+      version,
+      assets: [
+        ...buildFullPlatformAssets(OWNER, REPO, version),
+        buildAsset(OWNER, REPO, `app-${version}-win32-arm64-setup.exe`),
+      ],
+    });
+    const { app, backend } = configureTestAppWithReleases([release]);
+
+    for (const [url, filename] of [
+      // update.electronjs.org-style alias resolves the arm64 build
+      ["/download/win32-arm64", `app-${version}-win32-arm64-setup.exe`],
+      // the bare-os query keeps serving the x64 population
+      ["/download/windows", `app-${version}-x64-setup.exe`],
+    ] as const) {
+      const asset = await findAsset(backend, version, filename);
+      nockGithubReleasesAssetRedirect(nock, OWNER, REPO, asset);
+      await expectRedirectTo(app, url, filename);
+    }
+  });
 
   it("serves the platform build when preferUniversal is off", async () => {
     const { app, backend } = configureTestAppWithReleases(

--- a/test/unit/Architecture.spec.ts
+++ b/test/unit/Architecture.spec.ts
@@ -184,18 +184,18 @@ describe("Architecture", () => {
 
     it("should return correct architectures for windows", () => {
       const result = getSupportedArchByOs("windows");
-      expect(result).toEqual(["32", "64", "universal"]);
+      expect(result).toEqual(["32", "64", "arm64", "universal"]);
     });
 
     it("should return correct architectures for linux", () => {
       const result = getSupportedArchByOs("linux");
-      expect(result).toEqual(["32", "64"]);
+      expect(result).toEqual(["32", "64", "arm64"]);
     });
 
     it("should handle default case (same as linux)", () => {
       // Testing the default case by using an invalid OS that falls through
       const result = getSupportedArchByOs("invalid" as OperatingSystem);
-      expect(result).toEqual(["32", "64"]);
+      expect(result).toEqual(["32", "64", "arm64"]);
     });
   });
 
@@ -218,11 +218,11 @@ describe("Architecture", () => {
       it("should validate supported windows architectures", () => {
         expect(isValidArchForOS("windows", "32")).toBe(true);
         expect(isValidArchForOS("windows", "64")).toBe(true);
+        expect(isValidArchForOS("windows", "arm64")).toBe(true);
         expect(isValidArchForOS("windows", "universal")).toBe(true);
       });
 
       it("should reject invalid windows architectures", () => {
-        expect(isValidArchForOS("windows", "arm64")).toBe(false);
         expect(isValidArchForOS("windows", "invalid")).toBe(false);
       });
     });
@@ -231,10 +231,10 @@ describe("Architecture", () => {
       it("should validate supported linux architectures", () => {
         expect(isValidArchForOS("linux", "32")).toBe(true);
         expect(isValidArchForOS("linux", "64")).toBe(true);
+        expect(isValidArchForOS("linux", "arm64")).toBe(true);
       });
 
       it("should reject invalid linux architectures", () => {
-        expect(isValidArchForOS("linux", "arm64")).toBe(false);
         expect(isValidArchForOS("linux", "universal")).toBe(false);
         expect(isValidArchForOS("linux", "invalid")).toBe(false);
       });
@@ -245,7 +245,7 @@ describe("Architecture", () => {
         const invalidOS = "unknown" as OperatingSystem;
         expect(isValidArchForOS(invalidOS, "32")).toBe(true);
         expect(isValidArchForOS(invalidOS, "64")).toBe(true);
-        expect(isValidArchForOS(invalidOS, "arm64")).toBe(false);
+        expect(isValidArchForOS(invalidOS, "arm64")).toBe(true);
         expect(isValidArchForOS(invalidOS, "universal")).toBe(false);
       });
     });

--- a/test/unit/platforms.spec.ts
+++ b/test/unit/platforms.spec.ts
@@ -231,10 +231,7 @@ const tests: FilenameResolveTestTuple[] = [
     "windows",
     "arm64",
     "msix",
-    // arm64 isn't a supported windows platform (there is no windows_arm64),
-    // so the WINDOWS_MSIX_ARM64 key doesn't exist and the asset is dropped
-    // at ingestion like any other arm64 windows asset
-    null,
+    platforms.WINDOWS_MSIX_ARM64,
   ],
   [
     "Visibox-5.0.13.msixbundle",
@@ -268,6 +265,25 @@ const tests: FilenameResolveTestTuple[] = [
     undefined,
     platforms.WINDOWS_64,
   ],
+  // arm64 is a first-class platform in 2.0: these assets previously had no
+  // platform key and were dropped at ingestion
+  [
+    "app-2.7.0-win32-arm64-setup.exe",
+    "windows",
+    "arm64",
+    undefined,
+    platforms.WINDOWS_ARM64,
+  ],
+  [
+    "app-2.7.0-linux-arm64.tar.gz",
+    "linux",
+    "arm64",
+    undefined,
+    platforms.LINUX_ARM64,
+  ],
+  ["app-2.7.0-arm64.deb", "linux", "arm64", "deb", platforms.LINUX_DEB_ARM64],
+  ["app-2.7.0-arm64.rpm", "linux", "arm64", "rpm", platforms.LINUX_RPM_ARM64],
+  ["app-armv7l.tar.gz", "linux", "arm64", undefined, platforms.LINUX_ARM64],
 ];
 
 const fileNameByPlatformTests: [platform: Platform, filename: string][] = [

--- a/test/unit/resolveAssetForRelease.spec.ts
+++ b/test/unit/resolveAssetForRelease.spec.ts
@@ -139,6 +139,56 @@ describe("resolveAssetForRelease", () => {
       });
     });
 
+    describe("arm64 default policy", () => {
+      it("never resolves arm64 for an unconstrained-arch windows query", () => {
+        // the specificity rule alone would rank windows_arm64 over
+        // windows_64 by string length; bare-os requests must keep serving
+        // the broad x64 population
+        const assets = [
+          createAsset("app-win32-arm64-setup.exe", "windows_arm64"),
+          createAsset("app-win32-x64-setup.exe", "windows_64"),
+        ];
+        const release = createRelease(assets);
+
+        const result = resolveReleaseAssetForVersion(release, "windows");
+        expect(result).toBe(assets[1]);
+      });
+
+      it("resolves arm64 when explicitly requested", () => {
+        const assets = [
+          createAsset("app-win32-arm64-setup.exe", "windows_arm64"),
+          createAsset("app-win32-x64-setup.exe", "windows_64"),
+        ];
+        const release = createRelease(assets);
+
+        const result = resolveReleaseAssetForVersion(release, "windows_arm64");
+        expect(result).toBe(assets[0]);
+      });
+
+      it("still prefers osx universal over arm64 on bare osx queries", () => {
+        const assets = [
+          createAsset("app-arm64.dmg", "osx_arm64"),
+          createAsset("app-universal.dmg", "osx_universal"),
+          createAsset("app-x64.dmg", "osx_64"),
+        ];
+        const release = createRelease(assets);
+
+        const result = resolveReleaseAssetForVersion(release, "osx");
+        expect(result).toBe(assets[1]);
+      });
+
+      it("ranks linux arm64 below x64 on bare linux queries", () => {
+        const assets = [
+          createAsset("app-linux-arm64.tar.gz", "linux_arm64"),
+          createAsset("app-linux-x64.tar.gz", "linux_64"),
+        ];
+        const release = createRelease(assets);
+
+        const result = resolveReleaseAssetForVersion(release, "linux");
+        expect(result).toBe(assets[1]);
+      });
+    });
+
     describe("sorting logic", () => {
       it("should prefer longer platform types (more specific)", () => {
         const assets = [


### PR DESCRIPTION
## Summary

PR 5 of the 2.0 release-review series, building on #60's detection fixes.

Windows-on-ARM and Linux arm64 are mainstream Electron targets (update.electronjs.org serves `win32-arm64`; MSIX supports arm64 natively), but pecans had no `windows_arm64`/`linux_arm64` platforms — those assets were **silently dropped at ingestion**.

## Changes

- `PLATFORMS` gains `linux_arm64`, `linux_deb_arm64`, `linux_rpm_arm64`, `windows_arm64`, `windows_msix_arm64`. Single-arch arm64 `.msix` assets now ingest instead of being dropped.
- `/dl/windows/arm64` and `/dl/linux/arm64` resolve (arch validity maps updated); the legacy alias map gains `win-arm64`, `win32-arm64`, `windows-arm64`, `linux-arm64`, so update.electronjs.org-style ids work on the `/download` routes.
- **Resolution policy:** an unconstrained-arch query never defaults to arm64. Without this, the existing specificity rule would rank `windows_arm64` over `windows_64` by string length, and bare `/download/windows` links would start serving arm64 binaries to the x64 population. Explicit arm64 requests are unaffected, and osx bare queries keep preferring universal.
- Coverage: ingestion pins for all five new platforms, resolution-policy unit tests (bare windows/linux/osx vs explicit arm64), and integration tests for `/dl/*/arm64`, the `/download/win32-arm64` alias, and the bare-os x64 default.

**BREAKING CHANGE:** arm64 windows/linux assets that were previously invisible now ingest and serve for explicit arm64 queries; releases whose only asset for an os is arm64 now satisfy bare-os availability checks. Bare-os and x64 queries keep their previous resolutions.

## Testing

- `npm test` — 829 passed (33 files)
- `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ)_