### PR TITLE
chore!: remove getChannelFromQuery, rename download event payload keys

### DIFF
--- a/src/pecans.ts
+++ b/src/pecans.ts
@@ -6,7 +6,6 @@ import {
   Router,
 } from "express";
 import EventEmitter from "node:events";
-import type { ParsedQs } from "qs";
 import { Backend } from "./backends/index.js";
 import { errorHandler, NotFoundError } from "./errors.js";
 import {
@@ -287,19 +286,6 @@ export class Pecans extends EventEmitter {
     }
   }
 
-  async getChannelFromQuery(query: ParsedQs): Promise<string | undefined> {
-    const releases = await this.getReleases();
-    const channels = releases.getChannelNames();
-    const channel =
-      query.channel && typeof query.channel === "string"
-        ? query.channel
-        : "stable";
-    if (channels.includes(channel)) {
-      return channel;
-    }
-    return;
-  }
-
   protected getBaseUrl(req: Request) {
     return req.protocol + "://" + req.get("host") + this.opts.basePath;
   }
@@ -319,16 +305,10 @@ export class Pecans extends EventEmitter {
     release: PecansReleaseDTO,
     asset: PecansAssetDTO,
   ) {
-    this.emit("beforeDownload", {
-      req: req,
-      version: release,
-      platform: asset,
-    });
+    // payload keys renamed in 2.0: the release was published as `version`
+    // and the asset as `platform` (nuts-era naming)
+    this.emit("beforeDownload", { req, release, asset });
     await this.backend.serveAsset(asset, res);
-    this.emit("afterDownload", {
-      req: req,
-      version: release,
-      platform: asset,
-    });
+    this.emit("afterDownload", { req, release, asset });
   }
 }

--- a/test/unit/pecans.spec.ts
+++ b/test/unit/pecans.spec.ts
@@ -705,32 +705,6 @@ describe("Pecans", () => {
         });
       });
 
-      describe("getChannelFromQuery", () => {
-        it("should return valid channel from query", async () => {
-          const query = { channel: "stable" };
-          const result = await pecans.getChannelFromQuery(query);
-          expect(result).toBe("stable");
-        });
-
-        it("should default to stable channel", async () => {
-          const query = {};
-          const result = await pecans.getChannelFromQuery(query);
-          expect(result).toBe("stable");
-        });
-
-        it("should return undefined for invalid channels", async () => {
-          const query = { channel: "invalid" };
-          const result = await pecans.getChannelFromQuery(query);
-          expect(result).toBeUndefined();
-        });
-
-        it("should handle non-string channel values", async () => {
-          const query = { channel: ["stable"] };
-          const result = await pecans.getChannelFromQuery(query);
-          expect(result).toBe("stable");
-        });
-      });
-
       describe("serveAsset", () => {
         it("should emit events and call backend serveAsset", async () => {
           const req = createMockRequest();
@@ -745,16 +719,10 @@ describe("Pecans", () => {
 
           await (pecans as any).serveAsset(req, res, release, asset);
 
-          expect(beforeSpy).toHaveBeenCalledWith({
-            req,
-            version: release,
-            platform: asset,
-          });
-          expect(afterSpy).toHaveBeenCalledWith({
-            req,
-            version: release,
-            platform: asset,
-          });
+          // 2.0 payload shape: release/asset, not the nuts-era
+          // version/platform keys
+          expect(beforeSpy).toHaveBeenCalledWith({ req, release, asset });
+          expect(afterSpy).toHaveBeenCalledWith({ req, release, asset });
         });
       });
     });


### PR DESCRIPTION
## Summary

PR 6 of the 2.0 release-review series — the "breaking is free at a major" trims.

## Changes

- **Removed `Pecans.getChannelFromQuery`** — public but unused by every route handler and internal consumer; only its own tests exercised it.
- **Renamed the `beforeDownload`/`afterDownload` event payload keys** from the nuts-era `{req, version, platform}` to `{req, release, asset}`, matching what the values actually are (`version` held a release object, `platform` held an asset). Flagged in the plan for your veto — if you'd rather not churn integrators on this one, say so in review and I'll drop the rename commit while keeping the `getChannelFromQuery` removal.

**BREAKING CHANGE:** `Pecans.getChannelFromQuery` is removed; `beforeDownload`/`afterDownload` payloads are now `{req, release, asset}`.

## Testing

- `npm test` — 825 passed (33 files)
- `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ)_