### PR TITLE
feat!: PECANS_REFRESH_SECRET env wiring; header-only secret on the generic backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ This server provides an endpoint for [Squirrel auto-updater](https://github.com/
 
 Release lists are cached (2 hours by default). `POST /webhook/refresh` busts
 the cache without waiting for expiry; it is enabled by configuring a
-`refreshSecret` on the backend and disabled otherwise.
+`refreshSecret` on the backend and disabled otherwise. For the standalone
+server (`npm start`, Docker, Heroku), set the `PECANS_REFRESH_SECRET`
+environment variable — `configure()` passes it to the backend as the
+`refreshSecret`.
 
 - **GitHub backend**: point a GitHub _release_ webhook at
   `/webhook/refresh` with the secret set to your `refreshSecret`; the

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ the cache without waiting for expiry; it is enabled by configuring a
   payload signature is verified with
   [@octokit/webhooks](https://github.com/octokit/webhooks.js).
 - **Other backends** (base `Backend` middleware): send the `refreshSecret`
-  in an `X-Pecans-Secret` header or a `?secret=` query parameter. A valid
+  in an `X-Pecans-Secret` header (the `?secret=` query parameter was removed
+  in 2.0 — query strings leak secrets into proxy and access logs). A valid
   request responds `200 {"refreshed": true}`; a missing or wrong secret
-  responds `403`.
+  responds `403`. Use a high-entropy secret, e.g. `openssl rand -hex 32`.
 
 ## Documentation
 

--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -93,11 +93,12 @@ export abstract class Backend<TRaw = unknown> {
   // overrides this with signed-payload verification via @octokit/webhooks).
   //
   // The caller authenticates by sending the configured refreshSecret in an
-  // `X-Pecans-Secret` header or `?secret=` query parameter; a request on the
-  // watched path with a missing or wrong secret gets a 403. When no
-  // refreshSecret is configured the middleware is a pass-through and the
-  // endpoint stays disabled — the secret requirement prevents DOS attacks
-  // against update infrastructure.
+  // `X-Pecans-Secret` header; a request on the watched path with a missing
+  // or wrong secret gets a 403. The header is the only accepted transport -
+  // a ?secret= query parameter would leak the secret into proxy and access
+  // logs. When no refreshSecret is configured the middleware is a
+  // pass-through and the endpoint stays disabled — the secret requirement
+  // prevents DOS attacks against update infrastructure.
   // ex) `app.use(backend.getRefreshWebhookMiddleware('/api/backend/refresh'))`
   getRefreshWebhookMiddleware(
     // path that the middleware will watch.
@@ -114,19 +115,15 @@ export abstract class Backend<TRaw = unknown> {
         return;
       }
       // the refresh contract is POST-only (matching the GitHub backend's
-      // webhook middleware); other methods fall through so crawlers hitting
-      // a shared ?secret= link can't trigger refreshes and preflights
-      // aren't answered with 403
+      // webhook middleware); other methods fall through so crawlers can't
+      // trigger refreshes and preflights aren't answered with 403
       if (req.method !== "POST") {
         next();
         return;
       }
-      // the middleware is mounted with use(), so req.params is never
-      // populated here - the secret arrives as a header or query parameter
-      const query = req.query.secret;
-      const provided =
-        req.get("x-pecans-secret") ??
-        (typeof query === "string" ? query : undefined);
+      // header only: a ?secret= query parameter would leak the secret into
+      // proxy and access logs (removed in 2.0)
+      const provided = req.get("x-pecans-secret");
       if (!provided || !this.verifyRefreshSecret(provided)) {
         next(new ForbiddenError("Invalid refresh secret"));
         return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ export function configure() {
   const cacheMaxAge = process.env.PECANS_CACHE_MAX_AGE
     ? parseInt(process.env.PECANS_CACHE_MAX_AGE)
     : 60 * 60 * 2; // Default 2 hours
+  // enables POST /webhook/refresh (see README); without it the cache-bust
+  // endpoint stays disabled
+  const refreshSecret = process.env.PECANS_REFRESH_SECRET;
 
   const pecansOpts: PecansOptions = {
     // base path to inject between host and relative path. use for D.O. app service where
@@ -32,8 +35,10 @@ export function configure() {
   switch (PECANS_BACKEND) {
     case "PecansGithubBackend": {
       const backendEnv = PecansGitHubBackend.getEnvironment();
-      // Pass cacheMaxAge to the backend
-      const backend = PecansGitHubBackend.FromEnv(backendEnv, { cacheMaxAge });
+      const backend = PecansGitHubBackend.FromEnv(backendEnv, {
+        cacheMaxAge,
+        refreshSecret,
+      });
       const pecans = new Pecans(backend, pecansOpts);
       return { env: backendEnv, backend, pecans };
     }

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -182,8 +182,15 @@ describe("/webhook/refresh (generic backend secret middleware)", () => {
 });
 
 describe("PECANS_REFRESH_SECRET env wiring (configure())", () => {
+  // restore rather than delete, in case the developer's environment set it
+  const originalRefreshSecret = process.env.PECANS_REFRESH_SECRET;
+
   afterEach(() => {
-    delete process.env.PECANS_REFRESH_SECRET;
+    if (originalRefreshSecret === undefined) {
+      delete process.env.PECANS_REFRESH_SECRET;
+    } else {
+      process.env.PECANS_REFRESH_SECRET = originalRefreshSecret;
+    }
     nock.cleanAll();
   });
 

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -115,7 +115,8 @@ describe("/webhook/refresh (GitHub release webhook)", () => {
 
 describe("/webhook/refresh (generic backend secret middleware)", () => {
   // non-GitHub backends inherit the base Backend middleware, which
-  // authenticates via an X-Pecans-Secret header or ?secret= query parameter
+  // authenticates via the X-Pecans-Secret header only (a ?secret= query
+  // parameter would leak the secret into proxy/access logs; removed in 2.0)
   class RefreshCountingBackend extends Backend {
     public fetchCount = 0;
     constructor(opts?: BackendOpts) {
@@ -133,22 +134,22 @@ describe("/webhook/refresh (generic backend secret middleware)", () => {
     return { backend, app };
   }
 
-  it("refreshes and responds 200 given the secret as a query parameter", async () => {
+  it("refreshes and responds 200 given the X-Pecans-Secret header", async () => {
     const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
     const res = await supertest(app)
-      .post(`/webhook/refresh?secret=${SECRET}`)
+      .post("/webhook/refresh")
+      .set("X-Pecans-Secret", SECRET)
       .expect(200);
     expect(res.body).toEqual({ refreshed: true });
     expect(backend.fetchCount).toBe(1);
   });
 
-  it("refreshes and responds 200 given the X-Pecans-Secret header", async () => {
+  // the 1.x-era ?secret= transport is gone: query strings land in proxy
+  // and access logs, so a valid secret sent that way must not authenticate
+  it("rejects a valid secret sent as a query parameter", async () => {
     const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
-    await supertest(app)
-      .post("/webhook/refresh")
-      .set("X-Pecans-Secret", SECRET)
-      .expect(200);
-    expect(backend.fetchCount).toBe(1);
+    await supertest(app).post(`/webhook/refresh?secret=${SECRET}`).expect(403);
+    expect(backend.fetchCount).toBe(0);
   });
 
   it("responds 403 for a wrong secret without refreshing", async () => {
@@ -166,17 +167,22 @@ describe("/webhook/refresh (generic backend secret middleware)", () => {
     expect(backend.fetchCount).toBe(0);
   });
 
-  // POST-only contract: a GET with a valid secret (e.g. a crawler following
-  // a shared ?secret= link) must fall through without refreshing
+  // POST-only contract: other methods fall through without refreshing
   it("ignores non-POST requests even with a valid secret", async () => {
     const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
-    await supertest(app).get(`/webhook/refresh?secret=${SECRET}`).expect(404);
+    await supertest(app)
+      .get("/webhook/refresh")
+      .set("X-Pecans-Secret", SECRET)
+      .expect(404);
     expect(backend.fetchCount).toBe(0);
   });
 
   it("is a no-op 404 when no refreshSecret is configured", async () => {
     const { backend, app } = buildGenericApp();
-    await supertest(app).post(`/webhook/refresh?secret=${SECRET}`).expect(404);
+    await supertest(app)
+      .post("/webhook/refresh")
+      .set("X-Pecans-Secret", SECRET)
+      .expect(404);
     expect(backend.fetchCount).toBe(0);
   });
 });

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -155,7 +155,8 @@ describe("/webhook/refresh (generic backend secret middleware)", () => {
   it("responds 403 for a wrong secret without refreshing", async () => {
     const { backend, app } = buildGenericApp({ refreshSecret: SECRET });
     const res = await supertest(app)
-      .post("/webhook/refresh?secret=wrong")
+      .post("/webhook/refresh")
+      .set("X-Pecans-Secret", "wrong")
       .expect(403);
     expect(res.text).toContain("Invalid refresh secret");
     expect(backend.fetchCount).toBe(0);
@@ -233,6 +234,8 @@ describe("PECANS_REFRESH_SECRET env wiring (configure())", () => {
   });
 
   it("keeps the webhook disabled when the env var is unset", async () => {
+    // don't rely on the developer's environment; afterEach restores it
+    delete process.env.PECANS_REFRESH_SECRET;
     const { pecans } = configure();
     const app = express();
     app.use(pecans.router);

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -210,6 +210,13 @@ describe("PECANS_REFRESH_SECRET env wiring (configure())", () => {
       .set("X-Hub-Signature-256", signature)
       .send(payload)
       .expect(200);
+
+    // the release handler fires refreshCache without awaiting it; wait for
+    // the mocked list-releases call to be consumed so this validates the
+    // end-to-end wiring (and cannot race afterEach's nock.cleanAll)
+    await vi.waitFor(() => {
+      expect(nock.isDone()).toBe(true);
+    });
   });
 
   it("keeps the webhook disabled when the env var is unset", async () => {

--- a/test/integration/webhook.spec.ts
+++ b/test/integration/webhook.spec.ts
@@ -1,4 +1,5 @@
 import { Webhooks } from "@octokit/webhooks";
+import express from "express";
 import nock from "nock";
 import supertest from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +10,7 @@ import {
   buildRelease,
   buildFullPlatformAssets,
 } from "../fixtures/builders.js";
+import { configure } from "../../src/index.js";
 import {
   configurePecansTestApp,
   configureTestAppWithReleases,
@@ -176,5 +178,56 @@ describe("/webhook/refresh (generic backend secret middleware)", () => {
     const { backend, app } = buildGenericApp();
     await supertest(app).post(`/webhook/refresh?secret=${SECRET}`).expect(404);
     expect(backend.fetchCount).toBe(0);
+  });
+});
+
+describe("PECANS_REFRESH_SECRET env wiring (configure())", () => {
+  afterEach(() => {
+    delete process.env.PECANS_REFRESH_SECRET;
+    nock.cleanAll();
+  });
+
+  it("enables the refresh webhook on the standalone server", async () => {
+    process.env.PECANS_REFRESH_SECRET = SECRET;
+    const { pecans } = configure();
+    const app = express();
+    app.use(pecans.router);
+
+    // the refresh triggered by the webhook fetches the release list
+    nockGithubListReleases(
+      nock,
+      OWNER,
+      REPO,
+      buildStableReleaseSet(OWNER, REPO),
+    );
+
+    const { payload, signature } = await signedReleaseEvent(SECRET);
+    await supertest(app)
+      .post("/webhook/refresh")
+      .set("Content-Type", "application/json")
+      .set("X-GitHub-Event", "release")
+      .set("X-GitHub-Delivery", "env-wiring-delivery")
+      .set("X-Hub-Signature-256", signature)
+      .send(payload)
+      .expect(200);
+  });
+
+  it("keeps the webhook disabled when the env var is unset", async () => {
+    const { pecans } = configure();
+    const app = express();
+    app.use(pecans.router);
+    app.use((req, res) => {
+      res.status(404).send("Page not found");
+    });
+
+    const { payload, signature } = await signedReleaseEvent(SECRET);
+    await supertest(app)
+      .post("/webhook/refresh")
+      .set("Content-Type", "application/json")
+      .set("X-GitHub-Event", "release")
+      .set("X-GitHub-Delivery", "env-wiring-delivery-2")
+      .set("X-Hub-Signature-256", signature)
+      .send(payload)
+      .expect(404);
   });
 });

--- a/test/unit/backend-complete.spec.ts
+++ b/test/unit/backend-complete.spec.ts
@@ -131,7 +131,9 @@ describe("Backend Complete Coverage", () => {
       expect(mockNext).toHaveBeenCalledWith(expect.any(ForbiddenError));
     });
 
-    it("should refresh cache and respond 200 for a valid ?secret= query", async () => {
+    it("rejects a valid secret sent as a ?secret= query (removed in 2.0)", async () => {
+      // query strings leak secrets into proxy/access logs; the header is
+      // the only accepted transport
       backend = new TestBackend({ refreshSecret: "test-secret" });
       mockReq.query = { secret: "test-secret" };
 
@@ -141,12 +143,11 @@ describe("Backend Complete Coverage", () => {
       const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
       middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
-      await vi.waitFor(() => expect(mockRes.json).toHaveBeenCalled());
+      await vi.waitFor(() => expect(mockNext).toHaveBeenCalled());
 
-      expect(refreshCacheSpy).toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(200);
-      expect(mockRes.json).toHaveBeenCalledWith({ refreshed: true });
-      expect(mockNext).not.toHaveBeenCalled();
+      expect(refreshCacheSpy).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.any(ForbiddenError));
+      expect(mockRes.json).not.toHaveBeenCalled();
     });
 
     it("should accept the secret from the X-Pecans-Secret header", async () => {
@@ -169,7 +170,9 @@ describe("Backend Complete Coverage", () => {
 
     it("should call next with error when refreshCache fails", async () => {
       backend = new TestBackend({ refreshSecret: "test-secret" });
-      mockReq.query = { secret: "test-secret" };
+      mockReq.get.mockImplementation((name: string) =>
+        name.toLowerCase() === "x-pecans-secret" ? "test-secret" : undefined,
+      );
 
       const testError = new Error("Cache refresh failed");
       const refreshCacheSpy = vi

--- a/test/unit/backend-complete.spec.ts
+++ b/test/unit/backend-complete.spec.ts
@@ -103,7 +103,9 @@ describe("Backend Complete Coverage", () => {
     it("should call next() for non-POST methods on the watched path", () => {
       backend = new TestBackend({ refreshSecret: "test-secret" });
       mockReq.method = "GET";
-      mockReq.query = { secret: "test-secret" };
+      mockReq.get.mockImplementation((name: string) =>
+        name.toLowerCase() === "x-pecans-secret" ? "test-secret" : undefined,
+      );
       const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
       middleware(mockReq as unknown as Request, mockRes as Response, mockNext);
@@ -114,7 +116,9 @@ describe("Backend Complete Coverage", () => {
 
     it("should 403 when the secret does not match", () => {
       backend = new TestBackend({ refreshSecret: "test-secret" });
-      mockReq.query = { secret: "wrong-secret" };
+      mockReq.get.mockImplementation((name: string) =>
+        name.toLowerCase() === "x-pecans-secret" ? "wrong-secret" : undefined,
+      );
       const middleware = backend.getRefreshWebhookMiddleware("/api/refresh");
 
       middleware(mockReq as unknown as Request, mockRes as Response, mockNext);


### PR DESCRIPTION
## Summary

PR 7 of the 2.0 release-review series. Now **breaking-flagged** — scope grew per review discussion.

Two related refresh-webhook changes:

1. **`PECANS_REFRESH_SECRET` env wiring (non-breaking).** The README documents `POST /webhook/refresh`, but `configure()` never read a secret from the environment — standalone deployments (`npm start`, Docker, Heroku) could not enable it. `configure()` now passes the env var as the backend's `refreshSecret`.
2. **Header-only secret on the generic backend (breaking).** The base `Backend` middleware also accepted the secret as a `?secret=` query parameter; query strings routinely land in reverse-proxy and access logs, leaving the secret in plaintext on infrastructure the operator may not control. 2.0 accepts only the `X-Pecans-Secret` header. The GitHub backend's signed-webhook path is unaffected — the secret never travels on the wire there.

**BREAKING CHANGE:** the generic backend's `/webhook/refresh` no longer accepts `?secret=`; send the secret in the `X-Pecans-Secret` header.

## Testing

- `configure()`-level integration tests: env var set → signed release event drives a real refresh (asserted via nock consumption, per review); unset → endpoint stays a 404 pass-through. Verified red without the wiring.
- Generic-middleware tests updated: a *valid* secret via `?secret=` now pins a 403 with no refresh; header path unchanged; README updated (incl. `openssl rand -hex 32` recommendation).
- `npm test` — 827 passed (33 files); lint/typecheck/format:check clean.

## Review log

- Copilot r1 (nock never asserted) → fixed in `cefac2f`
- Copilot r2 (env teardown clobbers pre-set var) → fixed in `e12ed13`
- Maintainer: drop `?secret=` → `3fc1528`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ