### PR TITLE
feat: implement TRUST_PROXY for the standalone server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,16 +52,29 @@ export function configure() {
 /**
  * Parse the TRUST_PROXY env var into a value for express's "trust proxy"
  * setting. JSON values parse to their natural types ("true" -> true, "2" ->
- * 2, '["loopback","10.0.0.0/8"]' -> array); anything that isn't JSON is
+ * 2, '["loopback","10.0.0.0/8"]' -> array); anything that isn't JSON - or
+ * parses to a type express doesn't support, like an object or null - is
  * passed through verbatim ("loopback", "10.0.0.0/8, loopback", ...), which
  * express accepts as a comma-separated list.
  */
-export function parseTrustProxy(value: string): unknown {
+export function parseTrustProxy(
+  value: string,
+): boolean | number | string | string[] {
   try {
-    return JSON.parse(value);
+    const parsed: unknown = JSON.parse(value);
+    if (
+      typeof parsed === "boolean" ||
+      typeof parsed === "number" ||
+      typeof parsed === "string" ||
+      (Array.isArray(parsed) &&
+        parsed.every((entry) => typeof entry === "string"))
+    ) {
+      return parsed as boolean | number | string | string[];
+    }
   } catch {
-    return value;
+    // not JSON; fall through to the verbatim string
   }
+  return value;
 }
 
 export function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,33 @@ export function configure() {
   }
 }
 
+/**
+ * Parse the TRUST_PROXY env var into a value for express's "trust proxy"
+ * setting. JSON values parse to their natural types ("true" -> true, "2" ->
+ * 2, '["loopback","10.0.0.0/8"]' -> array); anything that isn't JSON is
+ * passed through verbatim ("loopback", "10.0.0.0/8, loopback", ...), which
+ * express accepts as a comma-separated list.
+ */
+export function parseTrustProxy(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
 export function main() {
   const { pecans } = configure();
   const port = process.env.PORT || 5000;
 
   const app = express();
+  // behind a TLS-terminating proxy (the normal production topology),
+  // req.protocol is "http" unless express trusts X-Forwarded-*; without
+  // this the Squirrel.Mac feed would emit http:// download urls
+  const trustProxy = process.env.TRUST_PROXY;
+  if (trustProxy !== undefined) {
+    app.set("trust proxy", parseTrustProxy(trustProxy));
+  }
   app.use(pecans.router);
   app.use((req: Request, res: Response, next: NextFunction): void => {
     res.status(404).send("Page not found");

--- a/test/integration/server-startup.spec.ts
+++ b/test/integration/server-startup.spec.ts
@@ -6,6 +6,7 @@ import { main } from "../../src/index.js";
 // Create mocks that will be populated in beforeEach
 let mockListen: any;
 let mockUse: any;
+let mockSet: any;
 let mockAddress: any;
 let mockClose: any;
 let mockServer: any;
@@ -51,6 +52,7 @@ describe("Server Startup Integration", () => {
     // Set up mock functions
     mockListen = vi.fn();
     mockUse = vi.fn();
+    mockSet = vi.fn();
     mockAddress = vi.fn();
     mockClose = vi.fn();
 
@@ -63,6 +65,7 @@ describe("Server Startup Integration", () => {
     mockApp = {
       use: mockUse,
       listen: mockListen,
+      set: mockSet,
     } as unknown as express.Express;
 
     // Set up express mock to return our mock app
@@ -139,6 +142,27 @@ describe("Server Startup Integration", () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         "Listening at unix:/tmp/server.sock",
       );
+    });
+
+    it("applies TRUST_PROXY to express's trust proxy setting", () => {
+      process.env.TRUST_PROXY = "true";
+      main();
+      expect(mockSet).toHaveBeenCalledWith("trust proxy", true);
+    });
+
+    it("passes non-JSON TRUST_PROXY values through verbatim", () => {
+      process.env.TRUST_PROXY = "loopback, 10.0.0.0/8";
+      main();
+      expect(mockSet).toHaveBeenCalledWith(
+        "trust proxy",
+        "loopback, 10.0.0.0/8",
+      );
+    });
+
+    it("leaves trust proxy unset without TRUST_PROXY", () => {
+      delete process.env.TRUST_PROXY;
+      main();
+      expect(mockSet).not.toHaveBeenCalled();
     });
 
     it("should set up error handling middleware", () => {

--- a/test/integration/update-mac.spec.ts
+++ b/test/integration/update-mac.spec.ts
@@ -28,6 +28,33 @@ describe("/update/:platform/:version (Squirrel.Mac)", () => {
     await supertest(app).get("/update/osx/2.7.0").expect(204);
   });
 
+  // TRUST_PROXY exists for this: behind a TLS-terminating proxy the feed's
+  // download url must come out https, which requires express to trust
+  // X-Forwarded-Proto (main() wires the env var to app.set("trust proxy"))
+  it("emits https download urls when the app trusts the proxy", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    app.set("trust proxy", true);
+    const res = await supertest(app)
+      .get("/update/osx/2.5.0")
+      .set("X-Forwarded-Proto", "https")
+      .expect(200);
+    expect(res.body.url).toMatch(/^https:\/\//);
+  });
+
+  it("keeps http urls when the proxy is not trusted", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/osx/2.5.0")
+      .set("X-Forwarded-Proto", "https")
+      .expect(200);
+    expect(res.body.url).toMatch(/^http:\/\//);
+    expect(res.body.url).not.toMatch(/^https:\/\//);
+  });
+
   it("204s when the client is ahead of every release", async () => {
     const { app } = configureTestAppWithReleases(
       buildStableReleaseSet(OWNER, REPO),

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -123,6 +123,13 @@ describe("Index", () => {
         "10.0.0.0/8, loopback",
       );
     });
+
+    it("falls back to the verbatim string for unsupported JSON types", () => {
+      // express's trust proxy accepts boolean/number/string/string[] only
+      expect(parseTrustProxy('{"a":1}')).toBe('{"a":1}');
+      expect(parseTrustProxy("null")).toBe("null");
+      expect(parseTrustProxy("[1,2]")).toBe("[1,2]");
+    });
   });
 
   describe("main function execution coverage", () => {

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { PecansGitHubBackend } from "../../src/backends/index.js";
-import { configure } from "../../src/index.js";
+import { configure, parseTrustProxy } from "../../src/index.js";
 
 describe("Index", () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -103,6 +103,25 @@ describe("Index", () => {
 
       // Clean up
       delete process.env.PECANS_BACKEND;
+    });
+  });
+
+  describe("parseTrustProxy", () => {
+    it("parses JSON scalars and arrays", () => {
+      expect(parseTrustProxy("true")).toBe(true);
+      expect(parseTrustProxy("false")).toBe(false);
+      expect(parseTrustProxy("2")).toBe(2);
+      expect(parseTrustProxy('["loopback","10.0.0.0/8"]')).toEqual([
+        "loopback",
+        "10.0.0.0/8",
+      ]);
+    });
+
+    it("passes non-JSON strings through verbatim", () => {
+      expect(parseTrustProxy("loopback")).toBe("loopback");
+      expect(parseTrustProxy("10.0.0.0/8, loopback")).toBe(
+        "10.0.0.0/8, loopback",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

PR 8 of the 2.0 release-review series. Non-breaking.

`deploy.md` has documented a `TRUST_PROXY` env var since the nuts era, but nothing reads it. Behind a TLS-terminating reverse proxy — the normal production topology — `req.protocol` stays `http`, so the Squirrel.Mac feed emitted `http://` download urls.

## Changes

- `main()` applies `app.set("trust proxy", parseTrustProxy(process.env.TRUST_PROXY))` when the env var is set.
- `parseTrustProxy` parses JSON when possible (`true`, hop counts like `2`, arrays) and passes everything else through verbatim (`loopback`, `10.0.0.0/8, loopback`), matching the old nuts JSON-parsing behavior.
- Tests at three levels: unit (`parseTrustProxy` value table), wiring (`main()` calls `app.set` with the parsed value / not at all when unset), and effect (Squirrel.Mac feed url is `https://` with a trusted `X-Forwarded-Proto`, stays `http://` untrusted).

Module consumers own their express app and call `app.set("trust proxy", ...)` themselves — unchanged.

## Testing

- `npm test` — 834 passed (33 files)
- `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ)_