### PR TITLE
feat!: update.electronjs.org-compatible format routes; remove /update ?filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ Pecans is an Electron Release Server.
     - `/update/channel/:channel/:platform/:version/RELEASES`
   - update.electronjs.org-compatible format segment (drop-in for
     [update-electron-app](https://github.com/electron/update-electron-app)-style
-    clients pointed at private repos)
-    - `/update/:platform-:arch/squirrel/:version` (+ `/RELEASES` for
-      Squirrel.Windows)
-    - `/update/:platform-:arch/msix/:version` — Squirrel.Mac-shaped JSON feed
-      for Electron's built-in MSIX updater (39.5+/40.2+/41+); also reachable
-      as `?filetype=msix` on the standard route
+    clients pointed at private repos). The platform segment is a single
+    `platform-arch` id such as `darwin-x64`, `darwin-arm64`, `win32-x64`,
+    or `win32-arm64`:
+    - `/update/:platform/squirrel/:version` (+ `/RELEASES` for
+      Squirrel.Windows), e.g. `/update/darwin-arm64/squirrel/1.2.3`
+    - `/update/:platform/msix/:version` — Squirrel.Mac-shaped JSON feed
+      for Electron's built-in MSIX updater (39.5+/40.2+/41+), e.g.
+      `/update/win32-x64/msix/1.2.3`; also reachable as `?filetype=msix`
+      on the standard route
 - API
   - `/api/channels` — release channels with their latest versions
   - `/api/versions` — releases, filterable with `?channel`, `?platform`, `?version`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Pecans is an Electron Release Server.
   - For Windows using Squirrel.Windows and NuGet packages
     - `/update/:platform/:version/RELEASES`
     - `/update/channel/:channel/:platform/:version/RELEASES`
+  - update.electronjs.org-compatible format segment (drop-in for
+    [update-electron-app](https://github.com/electron/update-electron-app)-style
+    clients pointed at private repos)
+    - `/update/:platform-:arch/squirrel/:version` (+ `/RELEASES` for
+      Squirrel.Windows)
+    - `/update/:platform-:arch/msix/:version` — Squirrel.Mac-shaped JSON feed
+      for Electron's built-in MSIX updater (39.5+/40.2+/41+); also reachable
+      as `?filetype=msix` on the standard route
 - API
   - `/api/channels` — release channels with their latest versions
   - `/api/versions` — releases, filterable with `?channel`, `?platform`, `?version`

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Pecans is an Electron Release Server.
       Squirrel.Windows), e.g. `/update/darwin-arm64/squirrel/1.2.3`
     - `/update/:platform/msix/:version` — Squirrel.Mac-shaped JSON feed
       for Electron's built-in MSIX updater (39.5+/40.2+/41+), e.g.
-      `/update/win32-x64/msix/1.2.3`; also reachable as `?filetype=msix`
-      on the standard route
+      `/update/win32-x64/msix/1.2.3`. The format segment is the only way
+      to select the msix feed: the nuts-era `?filetype` query on `/update`
+      was removed in 2.0 (`?filetype` remains on `/download`, where the
+      feed-minted urls use it)
 - API
   - `/api/channels` — release channels with their latest versions
   - `/api/versions` — releases, filterable with `?channel`, `?platform`, `?version`

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Pecans is an Electron Release Server.
       to select the msix feed: the nuts-era `?filetype` query on `/update`
       was removed in 2.0 (`?filetype` remains on `/download`, where the
       feed-minted urls use it)
+    - channel variants (a pecans extension; uejs has no channel concept):
+      `/update/channel/:channel/:platform/:format/:version` (+ `/RELEASES`),
+      e.g. `/update/channel/beta/win32-x64/msix/1.2.3`
 - API
   - `/api/channels` — release channels with their latest versions
   - `/api/versions` — releases, filterable with `?channel`, `?platform`, `?version`

--- a/src/http/updates.ts
+++ b/src/http/updates.ts
@@ -38,8 +38,9 @@ export function createUpdateRedirectHandler(ctx: PecansHttpContext) {
  * GET /update/:platform/:version (+ channel variant) - Squirrel.Mac update
  * feed: 204 when current, 200 {url, name, notes, pub_date} when an update
  * exists. The response shape is a frozen client contract.
- * opts.forcedFiletype pins the feed to one asset filetype regardless of
- * ?filetype (used by the /update/:platform/msix/:version format route).
+ * opts.forcedFiletype pins the feed to one asset filetype; without it the
+ * feed serves the squirrel zip contract. The /update/:platform/msix/:version
+ * format route forces "msix".
  */
 export function createUpdateOSXHandler(
   ctx: PecansHttpContext,
@@ -73,9 +74,9 @@ export function createUpdateOSXHandler(
       // Lowercase because the download route's filetype validation is
       // case-sensitive and the feed url embeds this value.
       const filetype = (opts.forcedFiletype || "zip").toLowerCase();
-      // an msix filetype implies the msix package format: Electron's MSIX
-      // updater consumes this same Squirrel.Mac-shaped feed with
-      // ?filetype=msix, and its assets never match the platform default
+      // an msix filetype implies the msix package format: the msix format
+      // route serves this same Squirrel.Mac-shaped feed pinned to msix
+      // assets, which never match the platform default
       const pkg = filetypeToPackageFormat(filetype);
 
       const versions = await ctx.service.filterReleases({

--- a/src/http/updates.ts
+++ b/src/http/updates.ts
@@ -38,8 +38,13 @@ export function createUpdateRedirectHandler(ctx: PecansHttpContext) {
  * GET /update/:platform/:version (+ channel variant) - Squirrel.Mac update
  * feed: 204 when current, 200 {url, name, notes, pub_date} when an update
  * exists. The response shape is a frozen client contract.
+ * opts.forcedFiletype pins the feed to one asset filetype regardless of
+ * ?filetype (used by the /update/:platform/msix/:version format route).
  */
-export function createUpdateOSXHandler(ctx: PecansHttpContext) {
+export function createUpdateOSXHandler(
+  ctx: PecansHttpContext,
+  opts: { forcedFiletype?: string } = {},
+) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       const versionParam = getStringParam(req, "version");
@@ -67,7 +72,9 @@ export function createUpdateOSXHandler(ctx: PecansHttpContext) {
       // case-sensitive, so embedding the caller's casing (e.g. "MSIX")
       // would produce a feed url the download route rejects.
       const filetype = (
-        getStringValueFromRequestQuery(req.query, "filetype") || "zip"
+        opts.forcedFiletype ||
+        getStringValueFromRequestQuery(req.query, "filetype") ||
+        "zip"
       ).toLowerCase();
       // an msix filetype implies the msix package format: Electron's MSIX
       // updater consumes this same Squirrel.Mac-shaped feed with
@@ -171,5 +178,46 @@ export function createUpdateWinHandler(ctx: PecansHttpContext) {
     } catch (err) {
       next(err);
     }
+  };
+}
+
+/**
+ * GET /update/:platform/:format/:version - update.electronjs.org-compatible
+ * format segment. "squirrel" serves the standard Squirrel.Mac-shaped feed;
+ * "msix" serves the same feed constrained to msix assets (Electron's
+ * built-in MSIX updater, 39.5+/40.2+/41+, consumes the Squirrel.Mac JSON
+ * shape). Anything else is a 404.
+ */
+export function createUpdateFormatHandler(ctx: PecansHttpContext) {
+  const squirrel = createUpdateOSXHandler(ctx);
+  const msix = createUpdateOSXHandler(ctx, { forcedFiletype: "msix" });
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const format = getStringParam(req, "format")?.toLowerCase();
+    if (format === "squirrel") return squirrel(req, res, next);
+    if (format === "msix") return msix(req, res, next);
+    next(
+      new NotFoundError(
+        `Unsupported update format (${format}), expected squirrel or msix`,
+      ),
+    );
+  };
+}
+
+/**
+ * GET /update/:platform/:format/:version/RELEASES - the Squirrel.Windows
+ * manifest under the update.electronjs.org-compatible format segment.
+ * Squirrel.Windows appends /RELEASES to its feed url itself, so only the
+ * "squirrel" format exists here (MSIX has no RELEASES manifest).
+ */
+export function createUpdateFormatWinHandler(ctx: PecansHttpContext) {
+  const win = createUpdateWinHandler(ctx);
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const format = getStringParam(req, "format")?.toLowerCase();
+    if (format === "squirrel") return win(req, res, next);
+    next(
+      new NotFoundError(
+        `Unsupported update format (${format}) for RELEASES, expected squirrel`,
+      ),
+    );
   };
 }

--- a/src/http/updates.ts
+++ b/src/http/updates.ts
@@ -66,16 +66,13 @@ export function createUpdateOSXHandler(
       const tag = versionParam;
 
       const channel = getStringParam(req, "channel") || "stable";
-      // non-string filetype values (repeated params) fall back to the default
-      // rather than being interpolated into the feed url. Canonicalize to
-      // lowercase: the download route's filetype validation is
-      // case-sensitive, so embedding the caller's casing (e.g. "MSIX")
-      // would produce a feed url the download route rejects.
-      const filetype = (
-        opts.forcedFiletype ||
-        getStringValueFromRequestQuery(req.query, "filetype") ||
-        "zip"
-      ).toLowerCase();
+      // the nuts-era ?filetype query on /update was removed in 2.0 in favor
+      // of the update.electronjs.org format segment
+      // (/update/:platform/:format/:version); the feed serves the squirrel
+      // zip contract unless a format route forces another filetype.
+      // Lowercase because the download route's filetype validation is
+      // case-sensitive and the feed url embeds this value.
+      const filetype = (opts.forcedFiletype || "zip").toLowerCase();
       // an msix filetype implies the msix package format: Electron's MSIX
       // updater consumes this same Squirrel.Mac-shaped feed with
       // ?filetype=msix, and its assets never match the platform default

--- a/src/pecans.ts
+++ b/src/pecans.ts
@@ -21,6 +21,8 @@ import {
 } from "./http/downloads.js";
 import { createNotesHandler } from "./http/notes.js";
 import {
+  createUpdateFormatHandler,
+  createUpdateFormatWinHandler,
   createUpdateOSXHandler,
   createUpdateRedirectHandler,
   createUpdateWinHandler,
@@ -91,6 +93,8 @@ export class Pecans extends EventEmitter {
     updateRedirect: ReturnType<typeof createUpdateRedirectHandler>;
     updateOSX: ReturnType<typeof createUpdateOSXHandler>;
     updateWin: ReturnType<typeof createUpdateWinHandler>;
+    updateFormat: ReturnType<typeof createUpdateFormatHandler>;
+    updateFormatWin: ReturnType<typeof createUpdateFormatWinHandler>;
     notes: ReturnType<typeof createNotesHandler>;
   };
 
@@ -132,6 +136,8 @@ export class Pecans extends EventEmitter {
       updateRedirect: createUpdateRedirectHandler(this.ctx),
       updateOSX: createUpdateOSXHandler(this.ctx),
       updateWin: createUpdateWinHandler(this.ctx),
+      updateFormat: createUpdateFormatHandler(this.ctx),
+      updateFormatWin: createUpdateFormatWinHandler(this.ctx),
       notes: createNotesHandler(this.ctx),
     };
 
@@ -192,6 +198,17 @@ export class Pecans extends EventEmitter {
     this.router.get(
       "/update/channel/:channel/:platform/:version/RELEASES",
       this.handleUpdateWin.bind(this),
+    );
+    // update.electronjs.org-compatible format segment (squirrel | msix).
+    // Registered after /update/:platform/:version/RELEASES so a literal
+    // RELEASES tail keeps hitting the Squirrel.Windows manifest route.
+    this.router.get(
+      "/update/:platform/:format/:version",
+      this.handleUpdateFormat.bind(this),
+    );
+    this.router.get(
+      "/update/:platform/:format/:version/RELEASES",
+      this.handleUpdateFormatWin.bind(this),
     );
 
     // translate HttpErrors into their status codes for every route above,
@@ -264,6 +281,22 @@ export class Pecans extends EventEmitter {
     next: NextFunction,
   ) {
     return this.handlers.updateWin(req, res, next);
+  }
+
+  protected async handleUpdateFormat(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) {
+    return this.handlers.updateFormat(req, res, next);
+  }
+
+  protected async handleUpdateFormatWin(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) {
+    return this.handlers.updateFormatWin(req, res, next);
   }
 
   protected async handleServeNotes(

--- a/src/pecans.ts
+++ b/src/pecans.ts
@@ -200,14 +200,25 @@ export class Pecans extends EventEmitter {
       this.handleUpdateWin.bind(this),
     );
     // update.electronjs.org-compatible format segment (squirrel | msix).
-    // Registered after /update/:platform/:version/RELEASES so a literal
-    // RELEASES tail keeps hitting the Squirrel.Windows manifest route.
+    // Registered after the literal-RELEASES routes so a RELEASES tail keeps
+    // hitting the Squirrel.Windows manifest routes. The channel variants
+    // are a pecans extension (uejs has no channel concept), mirroring the
+    // existing channel routes: channel-in-path survives Squirrel.Windows
+    // appending /RELEASES to the feed url and keeps one channel idiom.
     this.router.get(
       "/update/:platform/:format/:version",
       this.handleUpdateFormat.bind(this),
     );
     this.router.get(
       "/update/:platform/:format/:version/RELEASES",
+      this.handleUpdateFormatWin.bind(this),
+    );
+    this.router.get(
+      "/update/channel/:channel/:platform/:format/:version",
+      this.handleUpdateFormat.bind(this),
+    );
+    this.router.get(
+      "/update/channel/:channel/:platform/:format/:version/RELEASES",
       this.handleUpdateFormatWin.bind(this),
     );
 

--- a/src/utils/platforms.ts
+++ b/src/utils/platforms.ts
@@ -113,6 +113,10 @@ export const legacyPlatformMap: Record<string, Platform> = {
   "win32-arm64": platforms.WINDOWS_ARM64,
   "windows-arm64": platforms.WINDOWS_ARM64,
   "linux-arm64": platforms.LINUX_ARM64,
+  // process.platform-process.arch ids electron apps build directly
+  "win32-ia32": platforms.WINDOWS_32,
+  "linux-x64": platforms.LINUX_64,
+  "linux-amd64": platforms.LINUX_64,
 };
 
 export function mapLegacyPlatform(platform: string): string {

--- a/src/utils/platforms.ts
+++ b/src/utils/platforms.ts
@@ -94,6 +94,7 @@ export const legacyPlatformMap: Record<string, Platform> = {
   "darwin-x64": platforms.OSX_64,
   "darwin-amd64": platforms.OSX_64,
   "darwin-arm64": platforms.OSX_ARM64,
+  "darwin-universal": platforms.OSX_UNIVERSAL,
   mac: platforms.OSX_64,
   "mac-amd64": platforms.OSX_64,
   "mac-x64": platforms.OSX_64,

--- a/test/integration/msix.spec.ts
+++ b/test/integration/msix.spec.ts
@@ -54,9 +54,11 @@ function buildBundleOnlyReleaseSet(owner: string, repo: string) {
 }
 
 // Electron 41+'s autoUpdater for MSIX consumes the same Squirrel.Mac-shaped
-// JSON feed ({url, name, notes, pub_date}); the client requests it with
-// ?filetype=msix on the existing /update/:platform/:version route.
-describe("/update/:platform/:version?filetype=msix (Electron MSIX)", () => {
+// JSON feed ({url, name, notes, pub_date}); following update.electronjs.org
+// semantics, the client requests it via the msix format segment
+// (/update/:platform/msix/:version). The nuts-era ?filetype query on
+// /update was removed in 2.0.
+describe("/update/:platform/msix/:version (Electron MSIX)", () => {
   afterEach(() => nock.cleanAll());
 
   it("200s with a Squirrel.Mac-shaped descriptor when behind", async () => {
@@ -64,7 +66,7 @@ describe("/update/:platform/:version?filetype=msix (Electron MSIX)", () => {
       buildMsixReleaseSet(OWNER, REPO),
     );
     const res = await supertest(app)
-      .get("/update/win32-x64/2.5.0?filetype=msix")
+      .get("/update/win32-x64/msix/2.5.0")
       .expect(200);
     expectSquirrelMacResponse(res.body);
     expect(res.body.name).toBe("2.7.0");
@@ -78,9 +80,7 @@ describe("/update/:platform/:version?filetype=msix (Electron MSIX)", () => {
     const { app } = configureTestAppWithReleases(
       buildMsixReleaseSet(OWNER, REPO),
     );
-    await supertest(app)
-      .get("/update/win32-x64/2.7.0?filetype=msix")
-      .expect(204);
+    await supertest(app).get("/update/win32-x64/msix/2.7.0").expect(204);
   });
 
   it("204s when no msix assets are published", async () => {
@@ -88,9 +88,7 @@ describe("/update/:platform/:version?filetype=msix (Electron MSIX)", () => {
     const { app } = configureTestAppWithReleases(
       buildStableReleaseSet(OWNER, REPO),
     );
-    await supertest(app)
-      .get("/update/win32-x64/2.5.0?filetype=msix")
-      .expect(204);
+    await supertest(app).get("/update/win32-x64/msix/2.5.0").expect(204);
   });
 
   it("the update url resolves to the .msixbundle download", async () => {
@@ -98,7 +96,7 @@ describe("/update/:platform/:version?filetype=msix (Electron MSIX)", () => {
       buildMsixReleaseSet(OWNER, REPO),
     );
     const res = await supertest(app)
-      .get("/update/win32-x64/2.5.0?filetype=msix")
+      .get("/update/win32-x64/msix/2.5.0")
       .expect(200);
     expectSquirrelMacResponse(res.body);
     const path = new URL(res.body.url).pathname + new URL(res.body.url).search;
@@ -109,28 +107,14 @@ describe("/update/:platform/:version?filetype=msix (Electron MSIX)", () => {
     expect(download.headers.location).toContain(".msixbundle");
   });
 
-  it("supports filetype=msixbundle as well", async () => {
+  it("accepts the format segment case-insensitively", async () => {
+    // the feed url must embed the lowercased filetype or the follow-up
+    // download 400s (the download route's validation is case-sensitive)
     const { app } = configureTestAppWithReleases(
       buildMsixReleaseSet(OWNER, REPO),
     );
     const res = await supertest(app)
-      .get("/update/win32-x64/2.5.0?filetype=msixbundle")
-      .expect(200);
-    expectSquirrelMacResponse(res.body);
-    expect(res.body.url).toMatch(
-      /\/download\/version\/2\.7\.0\/windows_64\?filetype=msixbundle$/,
-    );
-  });
-
-  it("canonicalizes the filetype casing in the feed url", async () => {
-    // filetypeToPackageFormat accepts "MSIX" case-insensitively, and the
-    // download route's filetype validation is case-sensitive - the feed url
-    // must embed the lowercased filetype or the follow-up download 400s
-    const { app } = configureTestAppWithReleases(
-      buildMsixReleaseSet(OWNER, REPO),
-    );
-    const res = await supertest(app)
-      .get("/update/win32-x64/2.5.0?filetype=MSIX")
+      .get("/update/win32-x64/MSIX/2.5.0")
       .expect(200);
     expectSquirrelMacResponse(res.body);
     expect(res.body.url).toMatch(
@@ -144,19 +128,35 @@ describe("/update/:platform/:version?filetype=msix (Electron MSIX)", () => {
       buildBundleOnlyReleaseSet(OWNER, REPO),
     );
     const res = await supertest(app)
-      .get("/update/win32-x64/2.5.0?filetype=msix")
+      .get("/update/win32-x64/msix/2.5.0")
       .expect(200);
     expectSquirrelMacResponse(res.body);
     expect(res.body.name).toBe("2.7.0");
   });
 
   it("default windows updates keep resolving the platform default", async () => {
-    // no ?filetype: existing clients keep the zip-filetype feed url even
-    // when msix assets are published alongside the exe
+    // existing squirrel clients keep the zip-filetype feed url even when
+    // msix assets are published alongside the exe
     const { app } = configureTestAppWithReleases(
       buildMsixReleaseSet(OWNER, REPO),
     );
     const res = await supertest(app).get("/update/win32-x64/2.5.0").expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.url).toMatch(
+      /\/download\/version\/2\.7\.0\/windows_64\?filetype=zip$/,
+    );
+  });
+
+  it("ignores the removed ?filetype query on /update", async () => {
+    // 1.x-era semantics: ?filetype=msix selected the msix feed. 2.0 follows
+    // update.electronjs.org and only the format segment selects it; the
+    // query is ignored and the standard squirrel feed is served
+    const { app } = configureTestAppWithReleases(
+      buildMsixReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/win32-x64/2.5.0?filetype=msix")
+      .expect(200);
     expectSquirrelMacResponse(res.body);
     expect(res.body.url).toMatch(
       /\/download\/version\/2\.7\.0\/windows_64\?filetype=zip$/,

--- a/test/integration/update-format.spec.ts
+++ b/test/integration/update-format.spec.ts
@@ -1,0 +1,162 @@
+import nock from "nock";
+import supertest from "supertest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildAsset,
+  buildFullPlatformAssets,
+  buildRelease,
+  buildRELEASESContentForVersion,
+  buildStableReleaseSet,
+} from "../fixtures/builders.js";
+import { configureTestAppWithReleases, findAsset } from "../harness.js";
+import { expectSquirrelMacResponse } from "../helpers/contracts.js";
+import { nockGithubAssetContent } from "../nock/nockGithubAssetContent.js";
+
+nock.disableNetConnect();
+nock.enableNetConnect(/(localhost|127\.0\.0\.1)/);
+
+const OWNER = process.env.GITHUB_OWNER as string;
+const REPO = process.env.GITHUB_REPO as string;
+
+/** the stable set with msix assets published alongside the full matrix */
+function buildMsixReleaseSet(owner: string, repo: string) {
+  return ["2.7.0", "2.6.0", "2.5.0"].map((version) =>
+    buildRelease({
+      owner,
+      repo,
+      version,
+      assets: [
+        ...buildFullPlatformAssets(owner, repo, version),
+        buildAsset(owner, repo, `app_${version}_x64.msix`),
+      ],
+    }),
+  );
+}
+
+// update.electronjs.org-compatible surface: platform-arch ids
+// ("darwin-x64", "win32-x64") on the existing routes, plus the
+// /update/:platform/:format/:version segment where format is
+// squirrel (default protocols) or msix (Electron 39.5+/40.2+/41+).
+describe("/update/:platform/:format/:version (update.electronjs.org compat)", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("squirrel serves the Squirrel.Mac-shaped feed", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/darwin-x64/squirrel/2.5.0")
+      .expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.name).toBe("2.7.0");
+    expect(res.body.url).toMatch(
+      /\/download\/version\/2\.7\.0\/osx_64\?filetype=zip$/,
+    );
+  });
+
+  it("msix serves the feed constrained to msix assets", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildMsixReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/win32-x64/msix/2.5.0")
+      .expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.name).toBe("2.7.0");
+    expect(res.body.url).toMatch(
+      /\/download\/version\/2\.7\.0\/windows_64\?filetype=msix$/,
+    );
+  });
+
+  it("msix 204s when no msix assets exist", async () => {
+    // the stable set has windows assets but no msix packages
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    await supertest(app).get("/update/win32-x64/msix/2.5.0").expect(204);
+  });
+
+  it("squirrel 204s when the client is current", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    await supertest(app).get("/update/darwin-x64/squirrel/2.7.0").expect(204);
+  });
+
+  it("404s an unknown format", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/darwin-x64/appx/2.5.0")
+      .expect(404);
+    expect(res.text).toContain("Unsupported update format");
+  });
+
+  it("keeps the literal RELEASES tail on the Squirrel.Windows route", async () => {
+    // /update/:platform/:version/RELEASES must not be captured by the
+    // format route (version read as :format)
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const releasesAsset = await findAsset(backend, "2.7.0", "RELEASES");
+    nockGithubAssetContent(
+      nock,
+      OWNER,
+      REPO,
+      releasesAsset,
+      buildRELEASESContentForVersion("2.7.0"),
+    );
+    await supertest(app).get("/update/win32-x64/2.5.0/RELEASES").expect(200);
+  });
+});
+
+describe("/update/:platform/:format/:version/RELEASES", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("squirrel serves the rewritten RELEASES manifest", async () => {
+    const { app, backend } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const releasesAsset = await findAsset(backend, "2.7.0", "RELEASES");
+    nockGithubAssetContent(
+      nock,
+      OWNER,
+      REPO,
+      releasesAsset,
+      buildRELEASESContentForVersion("2.7.0"),
+    );
+    const res = await supertest(app)
+      .get("/update/win32-x64/squirrel/2.5.0/RELEASES")
+      .expect(200);
+    const body = Buffer.isBuffer(res.body)
+      ? res.body.toString("utf-8")
+      : (res.text ?? "");
+    expect(body).toContain("/dl/");
+  });
+
+  it("404s msix (no RELEASES manifest exists for MSIX)", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/win32-x64/msix/2.5.0/RELEASES")
+      .expect(404);
+    expect(res.text).toContain("Unsupported update format");
+  });
+});
+
+describe("update.electronjs.org platform-arch aliases", () => {
+  afterEach(() => nock.cleanAll());
+
+  it("serves darwin-universal via the standard route", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildStableReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/darwin-universal/2.5.0")
+      .expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.url).toMatch(/osx_universal\?filetype=zip$/);
+  });
+});

--- a/test/integration/update-format.spec.ts
+++ b/test/integration/update-format.spec.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   buildAsset,
   buildFullPlatformAssets,
+  buildMixedChannelReleaseSet,
   buildRelease,
   buildRELEASESContentForVersion,
   buildStableReleaseSet,
@@ -143,6 +144,103 @@ describe("/update/:platform/:format/:version/RELEASES", () => {
       .get("/update/win32-x64/msix/2.5.0/RELEASES")
       .expect(404);
     expect(res.text).toContain("Unsupported update format");
+  });
+});
+
+// channel variants are a pecans extension (uejs has no channel concept);
+// channel-in-path survives Squirrel.Windows appending /RELEASES to the
+// feed url, unlike a ?channel= query would
+describe("/update/channel/:channel/:platform/:format/:version", () => {
+  afterEach(() => nock.cleanAll());
+
+  /** beta releases carrying msix assets alongside the full matrix */
+  function buildBetaMsixReleaseSet(owner: string, repo: string) {
+    return ["2.8.0-beta.2", "2.8.0-beta.1"].map((version) =>
+      buildRelease({
+        owner,
+        repo,
+        version,
+        prerelease: true,
+        assets: [
+          ...buildFullPlatformAssets(owner, repo, version),
+          buildAsset(owner, repo, `app_${version}_x64.msix`),
+        ],
+      }),
+    );
+  }
+
+  it("squirrel serves the channel's feed", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/channel/beta/darwin-arm64/squirrel/2.8.0-beta.1")
+      .expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.name).toBe("2.8.0-beta.2");
+  });
+
+  it("msix serves the channel's msix feed", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildBetaMsixReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/channel/beta/win32-x64/msix/2.8.0-beta.1")
+      .expect(200);
+    expectSquirrelMacResponse(res.body);
+    expect(res.body.name).toBe("2.8.0-beta.2");
+    expect(res.body.url).toMatch(/windows_64\?filetype=msix$/);
+  });
+
+  it("404s an unknown format on the channel route", async () => {
+    const { app } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO),
+    );
+    const res = await supertest(app)
+      .get("/update/channel/beta/darwin-x64/appx/2.8.0-beta.1")
+      .expect(404);
+    expect(res.text).toContain("Unsupported update format");
+  });
+
+  it("squirrel serves the channel RELEASES manifest", async () => {
+    // Squirrel.Windows appends /RELEASES to the configured feed url
+    const { app, backend } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO),
+    );
+    const releasesAsset = await findAsset(backend, "2.8.0-beta.2", "RELEASES");
+    nockGithubAssetContent(
+      nock,
+      OWNER,
+      REPO,
+      releasesAsset,
+      buildRELEASESContentForVersion("2.8.0-beta.2"),
+    );
+    const res = await supertest(app)
+      .get("/update/channel/beta/win32-x64/squirrel/2.8.0-beta.1/RELEASES")
+      .expect(200);
+    const body = Buffer.isBuffer(res.body)
+      ? res.body.toString("utf-8")
+      : (res.text ?? "");
+    expect(body).toContain("/dl/");
+  });
+
+  it("keeps the literal RELEASES tail on the legacy channel route", async () => {
+    // /update/channel/:channel/:platform/:version/RELEASES must not be
+    // captured by the channel format route (version read as :format)
+    const { app, backend } = configureTestAppWithReleases(
+      buildMixedChannelReleaseSet(OWNER, REPO),
+    );
+    const releasesAsset = await findAsset(backend, "2.8.0-beta.2", "RELEASES");
+    nockGithubAssetContent(
+      nock,
+      OWNER,
+      REPO,
+      releasesAsset,
+      buildRELEASESContentForVersion("2.8.0-beta.2"),
+    );
+    await supertest(app)
+      .get("/update/channel/beta/win32-x64/2.8.0-beta.1/RELEASES")
+      .expect(200);
   });
 });
 

--- a/test/integration/update-mac.spec.ts
+++ b/test/integration/update-mac.spec.ts
@@ -78,30 +78,22 @@ describe("/update/:platform/:version (Squirrel.Mac)", () => {
     expect(res.body.notes).toBe("Notes for 2.7.0\nNotes for 2.6.0\n");
   });
 
-  it("honors an explicit ?filetype override in the feed url", async () => {
+  // the nuts-era ?filetype query on /update was removed in 2.0 in favor of
+  // the update.electronjs.org format segment; the query is ignored and the
+  // squirrel zip contract always applies (which also means raw req.query
+  // values can never be interpolated into the feed url)
+  it("ignores the removed ?filetype query", async () => {
     const { app } = configureTestAppWithReleases(
       buildStableReleaseSet(OWNER, REPO),
     );
-    const res = await supertest(app)
-      .get("/update/osx/2.5.0?filetype=dmg")
-      .expect(200);
-    expect(res.body.url).toMatch(
-      /\/download\/version\/2\.7\.0\/osx_64\?filetype=dmg$/,
-    );
-  });
-
-  // regression: raw req.query values must never be interpolated into the
-  // feed url - repeated params (arrays) fall back to the default filetype
-  it("falls back to filetype=zip for repeated ?filetype params", async () => {
-    const { app } = configureTestAppWithReleases(
-      buildStableReleaseSet(OWNER, REPO),
-    );
-    const res = await supertest(app)
-      .get("/update/osx/2.5.0?filetype=dmg&filetype=exe")
-      .expect(200);
-    expect(res.body.url).toMatch(
-      /\/download\/version\/2\.7\.0\/osx_64\?filetype=zip$/,
-    );
+    for (const query of ["?filetype=dmg", "?filetype=dmg&filetype=exe"]) {
+      const res = await supertest(app)
+        .get(`/update/osx/2.5.0${query}`)
+        .expect(200);
+      expect(res.body.url).toMatch(
+        /\/download\/version\/2\.7\.0\/osx_64\?filetype=zip$/,
+      );
+    }
   });
 
   it("accepts legacy platform aliases like darwin", async () => {

--- a/test/unit/pecans.spec.ts
+++ b/test/unit/pecans.spec.ts
@@ -1527,7 +1527,7 @@ describe("Pecans", () => {
           );
         });
 
-        it("should handle filetype parameter", async () => {
+        it("ignores the removed ?filetype query (2.0)", async () => {
           const mockReleases = [
             {
               version: "2.0.0",
@@ -1551,7 +1551,7 @@ describe("Pecans", () => {
 
           expect(res.send).toHaveBeenCalledWith(
             expect.objectContaining({
-              url: expect.stringContaining("filetype=dmg"),
+              url: expect.stringContaining("filetype=zip"),
             }),
           );
         });

--- a/test/unit/platforms.spec.ts
+++ b/test/unit/platforms.spec.ts
@@ -529,6 +529,21 @@ describe("Platforms", function () {
       expect(mapLegacyPlatform("win32-amd64")).toBe(platforms.WINDOWS_64);
     });
 
+    it("maps process.platform-process.arch ids electron apps build", () => {
+      // `${process.platform}-${process.arch}` covers the full matrix
+      expect(mapLegacyPlatform("darwin-x64")).toBe(platforms.OSX_64);
+      expect(mapLegacyPlatform("darwin-arm64")).toBe(platforms.OSX_ARM64);
+      expect(mapLegacyPlatform("darwin-universal")).toBe(
+        platforms.OSX_UNIVERSAL,
+      );
+      expect(mapLegacyPlatform("win32-x64")).toBe(platforms.WINDOWS_64);
+      expect(mapLegacyPlatform("win32-ia32")).toBe(platforms.WINDOWS_32);
+      expect(mapLegacyPlatform("win32-arm64")).toBe(platforms.WINDOWS_ARM64);
+      expect(mapLegacyPlatform("linux-x64")).toBe(platforms.LINUX_64);
+      expect(mapLegacyPlatform("linux-amd64")).toBe(platforms.LINUX_64);
+      expect(mapLegacyPlatform("linux-arm64")).toBe(platforms.LINUX_ARM64);
+    });
+
     it("should return original string for unmapped platforms", () => {
       expect(mapLegacyPlatform("unknown-platform")).toBe("unknown-platform");
       expect(mapLegacyPlatform("linux")).toBe("linux");


### PR DESCRIPTION
## Summary

PR 9 of the 2.0 release-review series. Now **breaking-flagged** — scope grew per maintainer decision: pecans follows update.electronjs.org semantics on the update surface instead of carrying the locally-invented `?filetype` query alongside them.

update.electronjs.org is the only actively maintained reference server for Electron's built-in autoUpdater, and it serves **public repos only**. Matching its URL scheme makes pecans the drop-in private-repo replacement for `update-electron-app`-style clients.

## Changes

- **`/update/:platform/:format/:version`** with `format` = `squirrel` | `msix` (case-insensitive):
  - `squirrel` → the standard Squirrel.Mac-shaped feed
  - `msix` → the same feed pinned to msix assets (Electron's built-in MSIX updater — 39.5+/40.2+/41+ — consumes the Squirrel.Mac JSON shape)
  - unknown formats → 404
- **`/update/:platform/:format/:version/RELEASES`** for Squirrel.Windows clients; `squirrel` only — MSIX has no RELEASES manifest.
- **`?filetype` removed from `/update` (breaking).** The query is ignored; feeds always serve the squirrel zip contract unless the `/msix/` segment selects the msix feed. `?filetype` on `/download` is unchanged (the feed-minted urls use it). No known deployed clients depend on `/update?filetype`: msix support has only existed in 2.0.0-next prereleases, and the sole known consumer (missioncontrol) is migrating to the format segment before shipping msix.
- `darwin-universal` joins the platform alias map; `createUpdateOSXHandler` gains a `forcedFiletype` option backing the msix dispatch.
- Route-order subtlety pinned by test: format routes register after the literal-`RELEASES` routes.
- README documents the new surface and the removal.

**BREAKING CHANGE:** `/update/:platform/:version` no longer honors `?filetype`; use `/update/:platform/msix/:version` for the MSIX feed. The default squirrel feed behavior is unchanged.

## Testing

- `npm test` — 843 passed (34 files); msix feed tests migrated onto the format segment, plus explicit pins that the removed query is ignored (single and repeated params)
- `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run build` — clean

## Review log

- Copilot r1 (README `:platform-:arch` pseudo-template misleading) → fixed in `c436b29`
- Maintainer: follow uejs semantics, drop `/update?filetype` → `b1b03b8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ