### PR TITLE
chore!: remove the 2.0-era deprecations

### DIFF
--- a/src/backends/github.ts
+++ b/src/backends/github.ts
@@ -13,7 +13,6 @@ import {
 } from "../models/index.js";
 // keep the module graph cycle-free: import specific util modules rather
 // than the ../utils barrel
-import { channelFromVersion } from "../utils/channelFromVersion.js";
 import { filenameToPlatform } from "../utils/platforms.js";
 import { PecansReleases } from "../models/PecansReleases.js";
 import { clean } from "semver";
@@ -248,7 +247,6 @@ export class PecansGitHubBackend extends Backend<GithubReleaseAsset> {
   normalizeRelease(release: GithubRelease): PecansRelease {
     const version =
       clean(release.tag_name, { loose: true }) || release.tag_name;
-    const channel = channelFromVersion(version);
     const notes = release.body || "";
     const published_at = release.published_at
       ? new Date(release.published_at)
@@ -274,7 +272,6 @@ export class PecansGitHubBackend extends Backend<GithubReleaseAsset> {
       .filter(isPecansAsset<GithubReleaseAsset>);
     const dto: PecansReleaseDTO = {
       version,
-      channel,
       notes,
       published_at,
       assets,
@@ -298,29 +295,5 @@ export class PecansGitHubBackend extends Backend<GithubReleaseAsset> {
       raw,
     };
     return new PecansAsset(dto);
-  }
-}
-
-// @deprecated
-export class GitHubBackend extends PecansGitHubBackend {
-  constructor(
-    protected token: string,
-    protected owner: string,
-    protected repo: string,
-    opts: PecansGitHubBackendOpts = {},
-  ) {
-    console.warn(
-      "GitHubBackend has been deprecated in favor of the namespaced PecansGithubBackend",
-    );
-    if (!token) {
-      throw new Error("Github Token Required");
-    }
-    if (!owner) {
-      throw new Error("Github Owner Required");
-    }
-    if (!repo) {
-      throw new Error("Github Repo Required");
-    }
-    super(owner, repo, token, opts);
   }
 }

--- a/src/http/updates.ts
+++ b/src/http/updates.ts
@@ -6,33 +6,7 @@ import { filetypeToPackageFormat } from "../utils/PackageFormat.js";
 import { mapLegacyPlatform, platformToQuery } from "../utils/platforms.js";
 import { generateRELEASES, parseRELEASES } from "../utils/win-releases.js";
 import type { PecansHttpContext } from "./context.js";
-import {
-  getStringParam,
-  getStringValueFromRequestQuery,
-  validateReqQueryPlatform,
-} from "./query.js";
-
-/** GET /update - @deprecated redirect to /update/:platform/:version. */
-export function createUpdateRedirectHandler(ctx: PecansHttpContext) {
-  return (req: Request, res: Response, next: NextFunction) => {
-    try {
-      // repeated params parse as arrays; only single strings form a valid
-      // redirect path, and they are encoded before being embedded in it
-      const version = getStringValueFromRequestQuery(req.query, "version");
-      if (!version) throw new BadRequestError('Requires "version" parameter');
-      const platform = getStringValueFromRequestQuery(req.query, "platform");
-      if (!platform) throw new BadRequestError('Requires "platform" parameter');
-      return res.redirect(
-        "/update/" +
-          encodeURIComponent(platform) +
-          "/" +
-          encodeURIComponent(version),
-      );
-    } catch (err) {
-      next(err);
-    }
-  };
-}
+import { getStringParam, validateReqQueryPlatform } from "./query.js";
 
 /**
  * GET /update/:platform/:version (+ channel variant) - Squirrel.Mac update

--- a/src/models/PecansRelease.ts
+++ b/src/models/PecansRelease.ts
@@ -9,12 +9,6 @@ import type { PecansReleaseQuery } from "./PecansReleaseQuery.js";
 export interface PecansReleaseDTO {
   // version
   assets: PecansAssetDTO[];
-  /**
-   * @deprecated ignored - the channel is always derived from the version's
-   * prerelease identifier (channelFromVersion), so channel and version can
-   * never disagree. Will be removed in 3.0.
-   */
-  channel: string;
   notes: string;
   // missing published_at indicates a draft that hasn't been published.
   published_at: Date;
@@ -31,14 +25,15 @@ export function isPecansAsset<TRaw = unknown>(
 
 export class PecansRelease implements PecansReleaseDTO {
   assets: PecansAsset[];
+  /** always derived from the version's prerelease identifier; a release's
+   * channel and version can never disagree (the 1.x DTO channel field was
+   * removed in 2.0) */
   channel: string;
   notes: string;
   published_at: Date;
   version: string;
 
   constructor(dto: PecansReleaseDTO) {
-    // the version string is the single source of truth for the channel;
-    // dto.channel is deliberately ignored (see PecansReleaseDTO.channel)
     this.channel = channelFromVersion(dto.version);
     this.assets = dto.assets
       .map((assetDTO) => {

--- a/src/pecans.ts
+++ b/src/pecans.ts
@@ -24,7 +24,6 @@ import {
   createUpdateFormatHandler,
   createUpdateFormatWinHandler,
   createUpdateOSXHandler,
-  createUpdateRedirectHandler,
   createUpdateWinHandler,
 } from "./http/updates.js";
 import type {
@@ -43,8 +42,6 @@ export * from "./http/query.js";
 const logger = Debug("pecans");
 
 export interface PecansSettings {
-  /** @deprecated accepted but unused (defaulted, no functional effect); will be removed in 3.0 */
-  timeout: number;
   /** Base path for all routes */
   basePath: string;
   /** Max age for releases cache (seconds) */
@@ -67,7 +64,6 @@ export class Pecans extends EventEmitter {
   protected opts: PecansSettings;
 
   static defaults: PecansSettings = {
-    timeout: 60 * 60 * 1000,
     cacheMaxAge: 60 * 60 * 2,
     basePath: "",
     preferUniversal: true,
@@ -90,7 +86,6 @@ export class Pecans extends EventEmitter {
     apiChannels: ReturnType<typeof createApiChannelsHandler>;
     apiStatus: ReturnType<typeof createApiStatusHandler>;
     apiVersions: ReturnType<typeof createApiVersionsHandler>;
-    updateRedirect: ReturnType<typeof createUpdateRedirectHandler>;
     updateOSX: ReturnType<typeof createUpdateOSXHandler>;
     updateWin: ReturnType<typeof createUpdateWinHandler>;
     updateFormat: ReturnType<typeof createUpdateFormatHandler>;
@@ -105,7 +100,6 @@ export class Pecans extends EventEmitter {
     super();
     this.opts = Object.assign({}, Pecans.defaults, opts);
     if (!this.opts.cacheMaxAge) this.opts.cacheMaxAge = 60 * 60 * 2;
-    if (!this.opts.timeout) this.opts.timeout = 60 * 60 * 1000;
     if (!this.opts.basePath) this.opts.basePath = "";
 
     this.service = new ReleaseService(this.backend, {
@@ -133,7 +127,6 @@ export class Pecans extends EventEmitter {
       apiChannels: createApiChannelsHandler(this.ctx),
       apiStatus: createApiStatusHandler(this.ctx),
       apiVersions: createApiVersionsHandler(this.ctx),
-      updateRedirect: createUpdateRedirectHandler(this.ctx),
       updateOSX: createUpdateOSXHandler(this.ctx),
       updateWin: createUpdateWinHandler(this.ctx),
       updateFormat: createUpdateFormatHandler(this.ctx),
@@ -181,8 +174,6 @@ export class Pecans extends EventEmitter {
     this.router.get("/api/versions", this.handleApiVersions.bind(this));
 
     this.router.get("/notes{/:version}", this.handleServeNotes.bind(this));
-    // @deprecated - the /update endpoint is deprecated, please use /update/:platform/:version
-    this.router.get("/update", this.handleUpdateRedirect.bind(this));
     this.router.get(
       "/update/:platform/:version",
       this.handleUpdateOSX.bind(this),
@@ -268,14 +259,6 @@ export class Pecans extends EventEmitter {
     next: NextFunction,
   ) {
     return this.handlers.apiVersions(req, res, next);
-  }
-
-  protected handleUpdateRedirect(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ) {
-    return this.handlers.updateRedirect(req, res, next);
   }
 
   protected async handleUpdateOSX(

--- a/test/integration/update-mac.spec.ts
+++ b/test/integration/update-mac.spec.ts
@@ -177,48 +177,15 @@ describe("/update/channel/:channel/:platform/:version (Squirrel.Mac)", () => {
   });
 });
 
-describe("/update (deprecated redirect)", () => {
+describe("/update (redirect removed in 2.0)", () => {
   afterEach(() => nock.cleanAll());
 
-  it("redirects to /update/:platform/:version", async () => {
+  // the nuts-era /update?platform=&version= redirect was removed with the
+  // rest of the 1.x deprecations; clients use /update/:platform/:version
+  it("404s the removed query-style endpoint", async () => {
     const { app } = configureTestAppWithReleases(
       buildStableReleaseSet(OWNER, REPO),
     );
-    const res = await supertest(app)
-      .get("/update?platform=osx&version=2.5.0")
-      .expect(302);
-    expect(res.headers.location).toBe("/update/osx/2.5.0");
-  });
-
-  it("400s when version or platform is missing", async () => {
-    const { app } = configureTestAppWithReleases(
-      buildStableReleaseSet(OWNER, REPO),
-    );
-    await supertest(app).get("/update?platform=osx").expect(400);
-    await supertest(app).get("/update?version=2.5.0").expect(400);
-  });
-
-  // regression: repeated params parse as arrays and must 400 rather than
-  // producing a malformed redirect path like /update/osx,win/1.0.0
-  it("400s on repeated query params", async () => {
-    const { app } = configureTestAppWithReleases(
-      buildStableReleaseSet(OWNER, REPO),
-    );
-    await supertest(app)
-      .get("/update?platform=osx&platform=win&version=2.5.0")
-      .expect(400);
-    await supertest(app)
-      .get("/update?platform=osx&version=2.5.0&version=2.6.0")
-      .expect(400);
-  });
-
-  it("encodes the platform and version into the redirect path", async () => {
-    const { app } = configureTestAppWithReleases(
-      buildStableReleaseSet(OWNER, REPO),
-    );
-    const res = await supertest(app)
-      .get("/update?platform=osx%2F..&version=2.5.0")
-      .expect(302);
-    expect(res.headers.location).toBe("/update/osx%2F../2.5.0");
+    await supertest(app).get("/update?platform=osx&version=2.5.0").expect(404);
   });
 });

--- a/test/unit/PecansRelease.spec.ts
+++ b/test/unit/PecansRelease.spec.ts
@@ -9,7 +9,6 @@ import {
   type PecansAssetDTO,
 } from "../../src/models/PecansAsset.js";
 import type { PecansReleaseQuery } from "../../src/models/PecansReleaseQuery.js";
-import { channelFromVersion } from "../../src/utils/channelFromVersion.js";
 
 describe("PecansRelease", () => {
   const createMockAssetDTO = (
@@ -32,7 +31,6 @@ describe("PecansRelease", () => {
       assets: [createMockAssetDTO()],
       // keep the fixture internally consistent: an explicit channel override
       // wins, otherwise derive it from the effective version
-      channel: channelFromVersion(version),
       notes: "Release notes",
       published_at: new Date("2023-01-01"),
       version,
@@ -67,7 +65,6 @@ describe("PecansRelease", () => {
       const release = new PecansRelease(
         createMockReleaseDTO({
           version: "1.0.0-beta.1",
-          channel: "nightly",
         }),
       );
       expect(release.channel).toBe("beta");

--- a/test/unit/PecansRelease.spec.ts
+++ b/test/unit/PecansRelease.spec.ts
@@ -29,8 +29,6 @@ describe("PecansRelease", () => {
     const version = overrides.version ?? "1.0.0";
     return {
       assets: [createMockAssetDTO()],
-      // keep the fixture internally consistent: an explicit channel override
-      // wins, otherwise derive it from the effective version
       notes: "Release notes",
       published_at: new Date("2023-01-01"),
       version,
@@ -59,15 +57,13 @@ describe("PecansRelease", () => {
       expect(release.channel).toBe("beta");
     });
 
-    it("should ignore dto.channel - the version string is the source of truth", () => {
-      // PecansReleaseDTO.channel is deprecated and deliberately ignored so
-      // channel and version can never disagree
-      const release = new PecansRelease(
-        createMockReleaseDTO({
-          version: "1.0.0-beta.1",
-        }),
-      );
-      expect(release.channel).toBe("beta");
+    it("derives the stable channel for release versions", () => {
+      // no prerelease identifier means the stable channel; numeric-only
+      // prerelease ids (1.0.0-2) also fall back to stable
+      expect(new PecansRelease(createMockReleaseDTO()).channel).toBe("stable");
+      expect(
+        new PecansRelease(createMockReleaseDTO({ version: "1.0.0-2" })).channel,
+      ).toBe("stable");
     });
 
     it("should filter out assets that fail to parse", () => {

--- a/test/unit/PecansReleases.spec.ts
+++ b/test/unit/PecansReleases.spec.ts
@@ -5,7 +5,6 @@ import {
   type PecansReleaseDTO,
 } from "../../src/models/PecansRelease.js";
 import type { PecansAssetDTO } from "../../src/models/PecansAsset.js";
-import { channelFromVersion } from "../../src/utils/channelFromVersion.js";
 
 describe("PecansReleases", () => {
   const createMockAssetDTO = (filename: string): PecansAssetDTO => ({
@@ -27,7 +26,6 @@ describe("PecansReleases", () => {
     const effectiveVersion = overrides.version ?? version;
     return {
       assets: [createMockAssetDTO(`${effectiveVersion}-app.dmg`)],
-      channel: channelFromVersion(effectiveVersion),
       notes: `Release notes for ${effectiveVersion}`,
       published_at: publishedAt,
       version: effectiveVersion,

--- a/test/unit/backend-cache.spec.ts
+++ b/test/unit/backend-cache.spec.ts
@@ -28,7 +28,6 @@ class TestBackend extends Backend {
 
     const mockReleaseDTO: PecansReleaseDTO = {
       version: "v1.0.0",
-      channel: "stable",
       published_at: new Date("2025-01-01T00:00:00Z"),
       notes: "Test release",
       assets: [mockAssetDTO],

--- a/test/unit/github.spec.ts
+++ b/test/unit/github.spec.ts
@@ -5,7 +5,6 @@ import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type GithubReleaseAsset,
-  GitHubBackend,
   PecansGitHubBackend,
   PecansGitHubBackendSettings,
 } from "../../src/backends/github.js";
@@ -802,41 +801,5 @@ describe("PecansGitHubBackend", () => {
       // raw carries the full GitHub asset for this backend's later use
       expect(result.raw).toBe(githubAsset);
     });
-  });
-});
-
-describe("GitHubBackend (deprecated)", () => {
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-  });
-
-  it("should create backend and show deprecation warning", () => {
-    const backend = new GitHubBackend("token", "owner", "repo");
-
-    expect(backend).toBeInstanceOf(GitHubBackend);
-    expect(backend).toBeInstanceOf(PecansGitHubBackend);
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      "GitHubBackend has been deprecated in favor of the namespaced PecansGithubBackend",
-    );
-  });
-
-  it("should throw error if token is missing", () => {
-    expect(() => new GitHubBackend("", "owner", "repo")).toThrow(
-      "Github Token Required",
-    );
-  });
-
-  it("should throw error if owner is missing", () => {
-    expect(() => new GitHubBackend("token", "", "repo")).toThrow(
-      "Github Owner Required",
-    );
-  });
-
-  it("should throw error if repo is missing", () => {
-    expect(() => new GitHubBackend("token", "owner", "")).toThrow(
-      "Github Repo Required",
-    );
   });
 });

--- a/test/unit/mergeReleaseNotes.spec.ts
+++ b/test/unit/mergeReleaseNotes.spec.ts
@@ -9,7 +9,6 @@ describe("mergeReleaseNotes", () => {
   const createMockRelease = (version: string, notes?: string) => {
     return new PecansRelease({
       version,
-      channel: "stable",
       published_at: new Date("2025-01-01T00:00:00Z"),
       notes: notes || `Release notes for ${version}`,
       assets: [],
@@ -35,7 +34,6 @@ describe("mergeReleaseNotes", () => {
       const releases = [
         new PecansRelease({
           version: "v1.0.0",
-          channel: "stable",
           published_at: new Date("2025-01-01T00:00:00Z"),
           notes: "", // Empty string is falsy
           assets: [],
@@ -85,7 +83,6 @@ describe("mergeReleaseNotes", () => {
     it("should handle releases with empty notes", () => {
       const release = new PecansRelease({
         version: "v1.0.0",
-        channel: "stable",
         published_at: new Date("2025-01-01T00:00:00Z"),
         notes: "", // Empty notes should use fallback
         assets: [],
@@ -99,7 +96,6 @@ describe("mergeReleaseNotes", () => {
     it("should handle releases with null notes", () => {
       const release = new PecansRelease({
         version: "v1.0.0",
-        channel: "stable",
         published_at: new Date("2025-01-01T00:00:00Z"),
         notes: "",
         assets: [],

--- a/test/unit/models-index.spec.ts
+++ b/test/unit/models-index.spec.ts
@@ -48,7 +48,6 @@ describe("Models Index Exports", () => {
 
     const releaseDTO = {
       assets: [assetDTO],
-      channel: "stable",
       notes: "Test release",
       published_at: new Date(),
       version: "1.0.0",

--- a/test/unit/pecans.spec.ts
+++ b/test/unit/pecans.spec.ts
@@ -59,7 +59,6 @@ class MockBackend extends Backend {
       // Create mock releases with proper structure
       const mockRelease = new PecansRelease({
         version: "1.0.0",
-        channel: "stable",
         notes: "Test release notes",
         published_at: new Date("2023-01-01"),
         assets: [
@@ -440,7 +439,6 @@ describe("Pecans", () => {
 
       it("should merge custom options with defaults", () => {
         const customOpts: PecansOptions = {
-          timeout: 30000,
           basePath: "/api",
           cacheMaxAge: 1800,
           preferUniversal: false,
@@ -457,7 +455,6 @@ describe("Pecans", () => {
 
       it("should set default values for missing required options", () => {
         const opts = {
-          timeout: 0,
           cacheMaxAge: 0,
           basePath: "",
         } as PecansOptions;
@@ -466,7 +463,6 @@ describe("Pecans", () => {
       });
 
       it("should have correct default values", () => {
-        expect(Pecans.defaults.timeout).toBe(60 * 60 * 1000);
         expect(Pecans.defaults.cacheMaxAge).toBe(60 * 60 * 2);
         expect(Pecans.defaults.basePath).toBe("");
         expect(Pecans.defaults.preferUniversal).toBe(true);
@@ -767,7 +763,6 @@ describe("Pecans", () => {
           // Create release with no matching assets
           const mockReleaseWithNoAssets = new PecansRelease({
             version: "2.0.0",
-            channel: "stable",
             notes: "Test",
             published_at: new Date(),
             assets: [],
@@ -794,7 +789,6 @@ describe("Pecans", () => {
           // Create release with assets that don't match the requested filename
           const mockReleaseWithDifferentAssets = new PecansRelease({
             version: "1.0.0",
-            channel: "stable",
             notes: "Test",
             published_at: new Date(),
             assets: [
@@ -852,7 +846,6 @@ describe("Pecans", () => {
           // Create a release that matches filename query but has assets that don't match
           const mockRelease = new PecansRelease({
             version: "1.0.0",
-            channel: "stable",
             notes: "Test",
             published_at: new Date(),
             assets: [
@@ -942,7 +935,6 @@ describe("Pecans", () => {
           // Create releases that exist but won't match the query due to different OS
           const mockReleaseWithDifferentOS = new PecansRelease({
             version: "1.0.0",
-            channel: "stable",
             notes: "Test",
             published_at: new Date(),
             assets: [
@@ -979,7 +971,6 @@ describe("Pecans", () => {
           // Mock release with no matching assets for the platform
           const mockReleaseWithDifferentAssets = new PecansRelease({
             version: "1.0.0",
-            channel: "stable",
             notes: "Test",
             published_at: new Date(),
             assets: [
@@ -1016,7 +1007,6 @@ describe("Pecans", () => {
           // Create release with Linux asset that has unsupported extension for the requested pkg format
           const mockReleaseWithWrongExtension = new PecansRelease({
             version: "1.0.0",
-            channel: "stable",
             notes: "Test",
             published_at: new Date(),
             assets: [
@@ -1071,7 +1061,6 @@ describe("Pecans", () => {
           // Create release with Linux deb assets
           const mockReleaseWithLinuxAssets = new PecansRelease({
             version: "1.0.0",
-            channel: "stable",
             notes: "Test",
             published_at: new Date(),
             assets: [
@@ -1319,7 +1308,6 @@ describe("Pecans", () => {
               }
               return new PecansRelease({
                 version: "1.0.0",
-                channel: "stable",
                 notes: "Test release notes",
                 published_at: new Date(),
                 assets: [
@@ -1379,47 +1367,6 @@ describe("Pecans", () => {
     describe("Update endpoints", () => {
       beforeEach(() => {
         pecans = new Pecans(mockBackend);
-      });
-
-      describe("handleUpdateRedirect", () => {
-        it("should redirect with platform and version parameters", () => {
-          const req = createMockRequest({
-            query: { platform: "osx_64", version: "1.0.0" },
-          });
-          const res = createMockResponse();
-          const next = createMockNext();
-
-          (pecans as any).handleUpdateRedirect(req, res, next);
-
-          expect(res.redirect).toHaveBeenCalledWith("/update/osx_64/1.0.0");
-          expect(next).not.toHaveBeenCalled();
-        });
-
-        it("should call next with error when version is missing", () => {
-          const req = createMockRequest({
-            query: { platform: "osx_64" },
-          });
-          const res = createMockResponse();
-          const next = createMockNext();
-
-          (pecans as any).handleUpdateRedirect(req, res, next);
-
-          expect(next).toHaveBeenCalledWith(expect.any(Error));
-          expect(res.redirect).not.toHaveBeenCalled();
-        });
-
-        it("should call next with error when platform is missing", () => {
-          const req = createMockRequest({
-            query: { version: "1.0.0" },
-          });
-          const res = createMockResponse();
-          const next = createMockNext();
-
-          (pecans as any).handleUpdateRedirect(req, res, next);
-
-          expect(next).toHaveBeenCalledWith(expect.any(Error));
-          expect(res.redirect).not.toHaveBeenCalled();
-        });
       });
 
       describe("handleUpdateOSX", () => {

--- a/test/unit/platforms.spec.ts
+++ b/test/unit/platforms.spec.ts
@@ -46,7 +46,6 @@ type FilenameResolveTestTuple = [
 
 const release: PecansReleaseDTO = {
   version: "v3.3.1",
-  channel: "stable",
   published_at: new Date(),
   notes: "",
   assets: [

--- a/test/unit/resolveAssetForRelease.spec.ts
+++ b/test/unit/resolveAssetForRelease.spec.ts
@@ -38,7 +38,6 @@ describe("resolveAssetForRelease", () => {
     // Helper function to create test release
     const createRelease = (assets: PecansAssetDTO[]): PecansReleaseDTO => ({
       assets,
-      channel: "stable",
       notes: "Release notes",
       published_at: new Date(),
       version: "1.0.0",

--- a/test/unit/service.spec.ts
+++ b/test/unit/service.spec.ts
@@ -28,7 +28,6 @@ function asset(filename: string, type: Platform) {
 function release(version: string, assets: ReturnType<typeof asset>[]) {
   return new PecansRelease({
     version,
-    channel: "ignored",
     notes: `notes ${version}`,
     published_at: new Date(`2024-01-0${1 + (version.charCodeAt(2) % 8)}`),
     assets,

--- a/test/unit/sortReleaseBySemVerDescending.spec.ts
+++ b/test/unit/sortReleaseBySemVerDescending.spec.ts
@@ -8,7 +8,6 @@ describe("sortReleaseBySemVerDescending", () => {
     return new PecansRelease({
       version,
       assets: [],
-      channel: "stable",
       notes: "Test release",
       published_at: new Date("2023-01-01"),
     });


### PR DESCRIPTION
## Summary

PR 9.5 of the 2.0 release-review series. Fixes #57 — per maintainer decision, the four deprecations are removed *at* the major rather than carried through the 2.x line, so **2.x ships with zero deprecations**.

## Removals and replacements

| Removed | Replacement |
| --- | --- |
| `GitHubBackend` class alias | `PecansGitHubBackend` (note the argument order differs: `owner, repo, token`) |
| `PecansSettings.timeout` | none needed — accepted but unused since the fork |
| `PecansReleaseDTO.channel` | none — channel always derives from the version's prerelease identifier; the derived `channel` property on `PecansRelease` is unchanged |
| `GET /update?platform=&version=` redirect | `/update/:platform/:version` |

Net −212 lines. Test updates: DTO literals across the suites drop the ignored `channel` field, the deprecated-class and redirect test blocks are replaced by a 404 removal pin, and the timeout option pins are gone.

## Testing

- `npm test` — 839 passed (34 files)
- `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtqyiALpbkcM68Bq68JcPZ)_