### PR TITLE
docs: add a requirements section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Pecans is an Electron Release Server.
 - Release Channels (`beta`, `alpha`, ...)
 - Express App (composable)
 
+## Requirements
+
+- Node.js >= 22.12
+- `@dopry/pecans` is ESM-only — load it with `import`; `require()` is not supported
+
 ## Deploy it / Start it
 
 [Follow our guide to deploy Pecans](https://pecans.darrelopry.com/v/main/docs/deploy).


### PR DESCRIPTION
Adds a short **Requirements** section to the README (Node.js >= 22.12, ESM-only) so the runtime constraints are visible up front instead of only inside the "Migrating from 1.x" section.

From the 2.0 release review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtqCsX7ptP36t5rdyaJJhM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtqCsX7ptP36t5rdyaJJhM)_