### PR TITLE
docs: note stricter windows filename detection in the migration guide

### DIFF
--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -75,6 +75,13 @@ secret, e.g. `openssl rand -hex 32`.
   classify as 64-bit (1.x read them as 32-bit), and letters inside words
   (`Charmap`) no longer classify as arm builds. Feeds over existing releases
   may resolve different assets after upgrade.
+- **Windows filename detection is stricter.** Only `win32`/`win64` markers
+  and the `.exe`/`.nupkg`/`.msix`/`.msixbundle` extensions classify an asset
+  as Windows. Portable archives named with a bare `win`/`windows` token
+  (e.g. `MyApp-1.0.0-win.zip`, `MyApp-windows-x64.zip`), which 1.x ingested,
+  are no longer recognized and are skipped at ingestion — include an
+  explicit `win32`/`win64` marker in the artifact name
+  (e.g. `MyApp-1.0.0-win64.zip`).
 - **arm64 is first-class.** `windows_arm64`, `linux_arm64` (and deb/rpm/msix
   variants) now ingest instead of being dropped. On bare-os requests
   (`/download/windows`) arm64 ranks last: it is only served when it is the


### PR DESCRIPTION
Documents an intentional 2.0 behavior change in the migration guide's "Behavior changes" section: 1.x classified any filename containing `win` as a Windows asset; 2.0 only recognizes `win32`/`win64` markers and the Windows-specific extensions (`.exe`/`.nupkg`/`.msix`/`.msixbundle`). Bare `-win`/`-windows` portable archives (e.g. `MyApp-1.0.0-win.zip`) are skipped at ingestion, so operators need to include an explicit `win32`/`win64` marker in artifact names.

From the 2.0 release review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtqCsX7ptP36t5rdyaJJhM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtqCsX7ptP36t5rdyaJJhM)_