### PR TITLE
fix: fall back to the default when PECANS_CACHE_MAX_AGE is not a number

### DIFF
--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -7,7 +7,7 @@ import { ForbiddenError } from "../errors.js";
 import type { PecansReleases } from "../models/index.js";
 import type { PecansAssetDTO } from "../models/PecansAsset.js";
 
-const DEFAULT_CACHE_MAX_AGE = 60 * 60 * 2; // 2 hours in seconds
+export const DEFAULT_CACHE_MAX_AGE = 60 * 60 * 2; // 2 hours in seconds
 
 export interface BackendOpts {
   refreshSecret?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,10 @@ import express, {
   type Response,
 } from "express";
 import { errorHandler } from "./errors.js";
-import { PecansGitHubBackend } from "./backends/index.js";
+import {
+  DEFAULT_CACHE_MAX_AGE,
+  PecansGitHubBackend,
+} from "./backends/index.js";
 import { Pecans, type PecansOptions } from "./pecans.js";
 
 export * from "./backends/index.js";
@@ -15,17 +18,17 @@ export * from "./pecans.js";
 export * from "./service.js";
 export * from "./utils/index.js";
 
-const DEFAULT_CACHE_MAX_AGE = 60 * 60 * 2; // 2 hours in seconds
-
 /**
- * Parse the PECANS_CACHE_MAX_AGE env var (seconds). A missing or
- * non-numeric value falls back to the default: a NaN would flow into the
- * backend's cache-age comparison, where every check comes out false and
- * the cache is never refreshed after the initial fetch.
+ * Parse the PECANS_CACHE_MAX_AGE env var (seconds). Anything but a
+ * non-negative integer falls back to the backend's default: a NaN would
+ * flow into the backend's cache-age comparison, where every check comes
+ * out false and the cache is never refreshed after the initial fetch,
+ * while parseInt-style permissive parsing would silently accept values
+ * like "3600ms" or "-1" (a negative age refreshes on every request).
  */
 export function parseCacheMaxAge(value: string | undefined): number {
-  const parsed = Number.parseInt(value ?? "", 10);
-  return Number.isNaN(parsed) ? DEFAULT_CACHE_MAX_AGE : parsed;
+  if (!value || !/^\d+$/.test(value)) return DEFAULT_CACHE_MAX_AGE;
+  return Number.parseInt(value, 10);
 }
 
 export function configure() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,23 @@ export * from "./pecans.js";
 export * from "./service.js";
 export * from "./utils/index.js";
 
+const DEFAULT_CACHE_MAX_AGE = 60 * 60 * 2; // 2 hours in seconds
+
+/**
+ * Parse the PECANS_CACHE_MAX_AGE env var (seconds). A missing or
+ * non-numeric value falls back to the default: a NaN would flow into the
+ * backend's cache-age comparison, where every check comes out false and
+ * the cache is never refreshed after the initial fetch.
+ */
+export function parseCacheMaxAge(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isNaN(parsed) ? DEFAULT_CACHE_MAX_AGE : parsed;
+}
+
 export function configure() {
   const PECANS_BACKEND = process.env.PECANS_BACKEND || "PecansGithubBackend";
   const basePath = process.env.PECANS_BASE_PATH || "";
-  const cacheMaxAge = process.env.PECANS_CACHE_MAX_AGE
-    ? parseInt(process.env.PECANS_CACHE_MAX_AGE)
-    : 60 * 60 * 2; // Default 2 hours
+  const cacheMaxAge = parseCacheMaxAge(process.env.PECANS_CACHE_MAX_AGE);
   // enables POST /webhook/refresh (see README); without it the cache-bust
   // endpoint stays disabled
   const refreshSecret = process.env.PECANS_REFRESH_SECRET;

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -126,6 +126,14 @@ describe("Index", () => {
       // cacheAge > cacheMaxAgeMs check is always false against NaN
       expect(parseCacheMaxAge("garbage")).toBe(7200);
     });
+
+    it("falls back for partially-numeric and negative values", () => {
+      // parseInt would read "3600ms" as 3600 and "-1" as -1; a negative
+      // age makes the cache look expired on every request
+      expect(parseCacheMaxAge("3600ms")).toBe(7200);
+      expect(parseCacheMaxAge("-1")).toBe(7200);
+      expect(parseCacheMaxAge("1.5")).toBe(7200);
+    });
   });
 
   describe("parseTrustProxy", () => {

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { PecansGitHubBackend } from "../../src/backends/index.js";
-import { configure, parseTrustProxy } from "../../src/index.js";
+import {
+  configure,
+  parseCacheMaxAge,
+  parseTrustProxy,
+} from "../../src/index.js";
 
 describe("Index", () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -103,6 +107,24 @@ describe("Index", () => {
 
       // Clean up
       delete process.env.PECANS_BACKEND;
+    });
+  });
+
+  describe("parseCacheMaxAge", () => {
+    it("parses numeric values as seconds", () => {
+      expect(parseCacheMaxAge("3600")).toBe(3600);
+      expect(parseCacheMaxAge("0")).toBe(0);
+    });
+
+    it("falls back to the 2 hour default when unset", () => {
+      expect(parseCacheMaxAge(undefined)).toBe(7200);
+      expect(parseCacheMaxAge("")).toBe(7200);
+    });
+
+    it("falls back to the 2 hour default for non-numeric values", () => {
+      // NaN would disable cache refreshes entirely: the backend's
+      // cacheAge > cacheMaxAgeMs check is always false against NaN
+      expect(parseCacheMaxAge("garbage")).toBe(7200);
     });
   });
 


### PR DESCRIPTION
`parseInt` of a non-numeric `PECANS_CACHE_MAX_AGE` produced `NaN`, which flowed into the backend's cache-age comparison where every check comes out false — the release cache was fetched once at startup and never refreshed again. `configure()` now parses the env var through a new exported `parseCacheMaxAge()` helper (mirroring `parseTrustProxy`), which falls back to the 2-hour default for missing or non-numeric values.

Includes unit tests for numeric, missing, empty, and garbage values.

From the 2.0 release review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtqCsX7ptP36t5rdyaJJhM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtqCsX7ptP36t5rdyaJJhM)_